### PR TITLE
Idanmz chmod+chown on bundles

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -3,8 +3,8 @@
 __INSTL_VERSION__:
     - 2         # major version e.g. python-batch
     - 1         # new major feature e.g. new command
-    - 11         # new minor feature e.g. new option to command, new python batch class
-    - 5         # bug fix
+    - 11        # new minor feature e.g. new option to command, new python batch class
+    - 6         # bug fix
 __INSTL_VERSION_STR_SHORT__: $(__INSTL_VERSION__[0]).$(__INSTL_VERSION__[1]).$(__INSTL_VERSION__[2]).$(__INSTL_VERSION__[3])
 
 # __INSTL_VERSION_STR_SHORT__ will be defined at run time by InstlInstanceBase.get_version_str

--- a/pyinstl/instlClientCopy.py
+++ b/pyinstl/instlClientCopy.py
@@ -248,6 +248,10 @@ class InstlClientCopy(InstlClient):
 
             if len(wtar_base_names) > 0:
                 retVal += Unwtar(source_path_abs, os.curdir)
+                log.warning(f"Experimental chown {os.curdir} - does not work as intended, it changes the inner files and not the bunlde")
+                retVal += Chown(path=Path(os.curdir),
+                              user_id=int(config_vars.get("ACTING_UID", -1)),
+                              group_id=int(config_vars.get("ACTING_GID", -1)), recursive=True)
         else:
             # it might be a dir that was wtarred
             retVal = self.create_copy_instructions_for_file(source_path, name_for_progress_message)

--- a/pyinstl/instlClientCopy.py
+++ b/pyinstl/instlClientCopy.py
@@ -248,10 +248,13 @@ class InstlClientCopy(InstlClient):
 
             if len(wtar_base_names) > 0:
                 retVal += Unwtar(source_path_abs, os.curdir)
-                # unwtar doesn't handle the owner which leads to binaries being owned by system on macOS Mojave and older
-                retVal += Chown(path=Path(os.curdir),
-                              user_id=int(config_vars.get("ACTING_UID", -1)),
-                              group_id=int(config_vars.get("ACTING_GID", -1)), recursive=True)
+
+            # change ownership on destination folder + currently copied folder name (e.g: /Applications/Waves/Plug-Ins V11/XXX.bundle/, /Applications/Waves/YYY.framework)
+            if self.mac_current_and_target:
+                target_folder = Path(config_vars.resolve_str(self.current_destination_folder), source_path_name).resolve() #initialized in create_copy_instructions_for_target_folder
+                retVal += Chown(path=target_folder,
+                                user_id=int(config_vars.get("ACTING_UID", -1)),
+                                group_id=int(config_vars.get("ACTING_GID", -1)), recursive=True)
         else:
             # it might be a dir that was wtarred
             retVal = self.create_copy_instructions_for_file(source_path, name_for_progress_message)

--- a/pyinstl/instlClientCopy.py
+++ b/pyinstl/instlClientCopy.py
@@ -248,7 +248,7 @@ class InstlClientCopy(InstlClient):
 
             if len(wtar_base_names) > 0:
                 retVal += Unwtar(source_path_abs, os.curdir)
-                log.warning(f"Experimental chown {os.curdir} - does not work as intended, it changes the inner files and not the bunlde")
+                # unwtar doesn't handle the owner which leads to binaries being owned by system on macOS Mojave and older
                 retVal += Chown(path=Path(os.curdir),
                               user_id=int(config_vars.get("ACTING_UID", -1)),
                               group_id=int(config_vars.get("ACTING_GID", -1)), recursive=True)


### PR DESCRIPTION
Added chown after unwtar step (added once in the end of the dir, as plugins have more than 1 tar)

This should help fix this
https://wavesaudio.atlassian.net/browse/CEN2-1862

and future version of Cofix (so it can be run without sudo)

increase version to 2.1.11.6