### PR TITLE
When doing cleanup in some cases where the exception is in the

### DIFF
--- a/aYaml/augmentedYaml.py
+++ b/aYaml/augmentedYaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 """

--- a/aYaml/test/test_all.py
+++ b/aYaml/test/test_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import unittest

--- a/aYaml/test/test_augmentedYaml.py
+++ b/aYaml/test/test_augmentedYaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/aYaml/yamlReader.py
+++ b/aYaml/yamlReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 """ YamlReader is a base class for writing specific classes that read yaml.
     when reading a yaml file, one or more documents can be found, each optionally

--- a/configVar/configVarOne.py
+++ b/configVar/configVarOne.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 """
     Copyright (c) 2012, Shai Shasag

--- a/configVar/configVarParser.py
+++ b/configVar/configVarParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import re
 import string

--- a/configVar/configVarStack.py
+++ b/configVar/configVarStack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 """

--- a/configVar/configVarYamlReader.py
+++ b/configVar/configVarYamlReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 """ ConfigVarYamlReader
 """

--- a/configVar/test/testConfigVar.py
+++ b/configVar/test/testConfigVar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import sys
 import os

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3.6 -m venv venv
+python3.9 -m venv venv
 source venv/bin/activate
-python3.6 -m pip install -r requirements.txt
-python3.6 -m pip install -r requirements_admin.txt
+python3.9 -m pip install -r requirements.txt
+python3.9 -m pip install -r requirements_admin.txt

--- a/db/indexItemTable.py
+++ b/db/indexItemTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -4,7 +4,7 @@ __INSTL_VERSION__:
     - 2         # major version e.g. python-batch
     - 1         # new major feature e.g. new command
     - 11        # new minor feature e.g. new option to command, new python batch class
-    - 9         # bug fix
+    - 10        # bug fix
 __INSTL_VERSION_STR_SHORT__: $(__INSTL_VERSION__[0]).$(__INSTL_VERSION__[1]).$(__INSTL_VERSION__[2]).$(__INSTL_VERSION__[3])
 
 # __INSTL_VERSION_STR_SHORT__ will be defined at run time by InstlInstanceBase.get_version_str

--- a/help/helpHelper.py
+++ b/help/helpHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/instl
+++ b/instl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 # -*- coding: utf-8 -*-
 
 """ main executable for instl """

--- a/pybatch/removeBatchCommands.py
+++ b/pybatch/removeBatchCommands.py
@@ -134,6 +134,7 @@ class RmFileOrDir(PythonBatchCommandBase):
         return f"""Remove '{self.path}'"""
 
     def __call__(self, *args, **kwargs):
+        resolved_path = None
         retry = kwargs.get("retry", True)
         try:
             PythonBatchCommandBase.__call__(self, *args, **kwargs)
@@ -145,7 +146,7 @@ class RmFileOrDir(PythonBatchCommandBase):
                 self.doing = f"""removing folder'{resolved_path}'"""
                 shutil.rmtree(resolved_path, onerror=self.who_locks_file_error_dict)
         except Exception as ex:
-            if retry:
+            if retry and resolved_path is not None:
                 kwargs["retry"] = False
                 log.info(f"Fixing permission for removing {resolved_path}")
                 from pybatch import FixAllPermissions

--- a/pybatch/subprocessBatchCommands.py
+++ b/pybatch/subprocessBatchCommands.py
@@ -434,7 +434,7 @@ class ExternalPythonExec(Subprocess):
     def get_run_args(self, run_args) -> None:
         """ Injecting the relevant OS python process into the run args instead of the empty string"""
         super().get_run_args(run_args)
-        python_executables = {'win32': ['py',  '-3.6'], 'darwin': ['python3.6']}
+        python_executables = {'win32': ['py',  '-3.9'], 'darwin': ['python3.9']}
         run_args.pop(0)  # Removing empty string
         for arg in reversed(python_executables[sys.platform]):
             run_args.insert(0, arg)

--- a/pybatch/test/test_MacOnlyBatchCommands.py
+++ b/pybatch/test/test_MacOnlyBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_PythonBatchBase.py
+++ b/pybatch/test/test_PythonBatchBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_WinOnlyBatchCommands.py
+++ b/pybatch/test/test_WinOnlyBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import unittest

--- a/pybatch/test/test_conditionalBatchCommands.py
+++ b/pybatch/test/test_conditionalBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import unittest

--- a/pybatch/test/test_copyBatchCommands.py
+++ b/pybatch/test/test_copyBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import sys
 import os

--- a/pybatch/test/test_fileSystemBatchCommands.py
+++ b/pybatch/test/test_fileSystemBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_info_mapBatchCommands.py
+++ b/pybatch/test/test_info_mapBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import unittest

--- a/pybatch/test/test_removeBatchCommands.py
+++ b/pybatch/test/test_removeBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_reportingBatchCommands.py
+++ b/pybatch/test/test_reportingBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_subprocessBatchCommands.py
+++ b/pybatch/test/test_subprocessBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys
@@ -269,8 +269,8 @@ class TestPythonBatchSubprocess(unittest.TestCase):
 
         self.pbt.batch_accum.clear(section_name="doit")
         self.pbt.batch_accum += MakeDir(folder_)
-        self.pbt.batch_accum += Subprocess("python3.6", "--version")
-        self.pbt.batch_accum += Subprocess("python3.6", "-c", "for i in range(4): print(i)")
+        self.pbt.batch_accum += Subprocess("python3.9", "--version")
+        self.pbt.batch_accum += Subprocess("python3.9", "-c", "for i in range(4): print(i)")
         self.pbt.exec_and_capture_output()
 
     def test_Subprocess_detached(self):
@@ -300,7 +300,7 @@ class TestPythonBatchSubprocess(unittest.TestCase):
         t = Timer(2, delete_abort_file)
         t.start()
 
-        cmd = ['python3.6', test_file]
+        cmd = ['python3.9', test_file]
         with self.assertRaises(ProcessTerminatedExternally):
             with assert_timeout(3):
                 run_process(cmd, shell=(sys.platform == 'win32'), abort_file=abort_file)

--- a/pybatch/test/test_svnBatchCommands.py
+++ b/pybatch/test/test_svnBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pybatch/test/test_wtarBatchCommands.py
+++ b/pybatch/test/test_wtarBatchCommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/connectionBase.py
+++ b/pyinstl/connectionBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import abc

--- a/pyinstl/curlHelper.py
+++ b/pyinstl/curlHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/pyinstl/installItemGraph.py
+++ b/pyinstl/installItemGraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import utils
 from configVar import config_vars

--- a/pyinstl/instlAdmin.py
+++ b/pyinstl/instlAdmin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import logging
 log = logging.getLogger()

--- a/pyinstl/instlClient.py
+++ b/pyinstl/instlClient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import os
 import sys

--- a/pyinstl/instlClientCopy.py
+++ b/pyinstl/instlClientCopy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/instlClientRemove.py
+++ b/pyinstl/instlClientRemove.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 
 import os

--- a/pyinstl/instlClientReport.py
+++ b/pyinstl/instlClientReport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/pyinstl/instlClientSync.py
+++ b/pyinstl/instlClientSync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 from configVar import config_vars

--- a/pyinstl/instlClientUninstall.py
+++ b/pyinstl/instlClientUninstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 from collections import deque, defaultdict
 from configVar import config_vars

--- a/pyinstl/instlDoIt.py
+++ b/pyinstl/instlDoIt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import logging
 log = logging.getLogger()

--- a/pyinstl/instlException.py
+++ b/pyinstl/instlException.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 class InstlException(Exception):

--- a/pyinstl/instlGui.py
+++ b/pyinstl/instlGui.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/instlInstanceBase.py
+++ b/pyinstl/instlInstanceBase.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 import os
 import sys

--- a/pyinstl/instlInstanceBase_interactive.py
+++ b/pyinstl/instlInstanceBase_interactive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/instlInstanceSyncBase.py
+++ b/pyinstl/instlInstanceSyncBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import sys
 import os

--- a/pyinstl/instlInstanceSync_boto.py
+++ b/pyinstl/instlInstanceSync_boto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 from .instlInstanceSyncBase import InstlInstanceSync

--- a/pyinstl/instlInstanceSync_p4.py
+++ b/pyinstl/instlInstanceSync_p4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 from .instlInstanceSyncBase import InstlInstanceSync

--- a/pyinstl/instlInstanceSync_svn.py
+++ b/pyinstl/instlInstanceSync_svn.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 import utils
 from .instlInstanceSyncBase import InstlInstanceSync

--- a/pyinstl/instlInstanceSync_url.py
+++ b/pyinstl/instlInstanceSync_url.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 from collections import defaultdict
 import urllib

--- a/pyinstl/instlMisc.py
+++ b/pyinstl/instlMisc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import shlex
 import threading

--- a/pyinstl/test/test_itemTable.py
+++ b/pyinstl/test/test_itemTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/test/test_utils.py
+++ b/pyinstl/test/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/pyinstl/test_all.py
+++ b/pyinstl/test_all.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 import os
 import sys

--- a/python_venv_sudo.sh
+++ b/python_venv_sudo.sh
@@ -8,4 +8,4 @@ SCRIPT_FOLDER=$(dirname $SCRIPT)
 echo ${PYTHONPATH}
 
 source "${SCRIPT_FOLDER}/venv/bin/activate"
-sudo python3.6 "$@"
+sudo python3.9 "$@"

--- a/svnTree/svnTable.py
+++ b/svnTree/svnTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/svnTree/test/test_SVNItem.py
+++ b/svnTree/test/test_SVNItem.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 import os
 import sys

--- a/svnTree/test/test_SVNTree.py
+++ b/svnTree/test/test_SVNTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import os

--- a/utils/extract_info.py
+++ b/utils/extract_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import os
 import sys

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import sys
 import os

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 """

--- a/utils/ls.py
+++ b/utils/ls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import sys
 import os

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys

--- a/utils/multi_file.py
+++ b/utils/multi_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 import io
 import os

--- a/utils/parallel_run.py
+++ b/utils/parallel_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import subprocess

--- a/utils/searchPaths.py
+++ b/utils/searchPaths.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.6
-
+#!/usr/bin/env python3.9
 
 """
     Manage list of include search paths, and help find files

--- a/utils/str_utils.py
+++ b/utils/str_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 
 import sys


### PR DESCRIPTION
The "resolved_path" maybe undefined which triggers wrong exception handling(try to fix permission)

Added check to make sure that when the resolved_path is undefined simply raise the error without attempting to fix the folder permission