### PR TITLE
Convert path in binary_details to string

### DIFF
--- a/db/indexItemTable.py
+++ b/db/indexItemTable.py
@@ -1299,7 +1299,8 @@ class IndexItemsTable(object):
         binaries_version_to_insert = list()
         for binary_details in binaries_version_list:
             folder, name = os.path.split(binary_details[0])
-            binaries_version_to_insert.append((name, *binary_details))
+            path_str = str(binary_details[0])
+            binaries_version_to_insert.append((name, path_str, *binary_details[1:]))
         self.add_binary_versions(binaries_version_to_insert)
 
     def add_binary_versions(self, binaries_version_list):


### PR DESCRIPTION
Data that goes into add_binary_versions should be string, not PosixPath, so that the DB insert query does not fail and return an exception.