### PR TITLE
Add ARM and Intel specific OS types for Mac to TARGET_OS_NAMES default values

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -40,6 +40,10 @@ Win_ALL_OS_NAMES:
 
 Mac_ALL_OS_NAMES:
     - Mac
+    - Mac32
+    - Mac64
+    - MacArm
+    - MacIntel
 
 BASE_REPO_REV: 1
 LAST_PROGRESS: 0


### PR DESCRIPTION
Added MacOS variants by processor type to defaults in main.yaml. When creating an installer for Mac on a Windows machine, all processor types (ARM/Intel) need to be considered, and their index entries (MacIntel/MacArm vs. just Mac) copied to the final result folder also.