### PR TITLE
Dead code, unused imports, and two bugs they were hiding

### DIFF
--- a/aYaml/augmentedYaml.py
+++ b/aYaml/augmentedYaml.py
@@ -27,7 +27,6 @@
 """
 
 import sys
-import os
 import yaml
 from collections import OrderedDict
 from typing import Any, List
@@ -470,7 +469,7 @@ if __name__ == "__main__":
                     a_node_as_tdw = nodeToYamlDumpWrap(a_node)
                     docWrap = YamlDumpDocWrap(a_node_as_tdw)
                     writeAsYaml(docWrap)
-    except Exception as ex:
+    except Exception:
         import traceback
         tb = traceback.format_exc()
         print(tb)

--- a/db/dbMaster.py
+++ b/db/dbMaster.py
@@ -1,7 +1,6 @@
 import os
 import sqlite3
 from contextlib import contextmanager
-import datetime
 import inspect
 from pathlib import Path
 from _collections import defaultdict
@@ -141,7 +140,6 @@ class DBMaster(object):
             self.__conn = None
         if bool(config_vars.get("PRINT_STATISTICS_DB", "False")) and self.statistics:
             for name, stats in sorted(self.statistics.items()):
-                average = stats.time/stats.count
                 print(f"{name}, {repr(stats)}")
 
                 max_count = max(self.statistics.items(), key=lambda S: S[1].count)
@@ -162,7 +160,7 @@ class DBMaster(object):
             self.__curs.execute(get_pragma_q)
             pragma_value = self.__curs.fetchone()[0]
         except Exception as ex:  # just return the default value
-            pass
+            log.debug("get_db_pragma(%s) failed, using default: %s", pragma_name, ex)
         return pragma_value
 
     def begin(self):
@@ -213,7 +211,7 @@ class DBMaster(object):
             if not description:
                 try:  # sporadically inspect.stack()[2] will raise 'list index out of range'
                     description = inspect.stack()[2][3]
-                except IndexError as ex:
+                except IndexError:
                     description = "unknown"
             with self.ProgressCallBacker(self, description, progress_callback, progress_callback_n_instructions):
                 #time1 = time.perf_counter()
@@ -224,7 +222,7 @@ class DBMaster(object):
                 #if self.print_execute_times:
                 #    print('DB transaction %s took %0.3f ms' % (description, (time2-time1)*1000.0))
                 #self.statistics[description].add_instance((time2-time1)*1000.0)
-        except sqlite3.OperationalError as s3oo:
+        except sqlite3.OperationalError:
             if not self.memory_db:
                 log.error("database error, disk %s", str(shutil.disk_usage(self.db_file_path.parent)), exc_info=True)
             self.rollback()
@@ -237,40 +235,20 @@ class DBMaster(object):
         """ returns a cursor for SELECT queries.
             no commit is done
         """
-        try:
-            if not description:
-                description = inspect.stack()[2][3]
-            with self.ProgressCallBacker(self, description, progress_callback, progress_callback_n_instructions):
-                #time1 = time.perf_counter()
-                yield self.__conn.cursor()
-                #time2 = time.perf_counter()
-                #if self.print_execute_times:
-                #    if not description:
-                #        description = inspect.stack()[2][3]
-                #    print('DB selection %s took %0.3f ms' % (description, (time2-time1)*1000.0))
-                #self.statistics[description].add_instance((time2-time1)*1000.0)
-        except Exception as ex:
-            raise
+        if not description:
+            description = inspect.stack()[2][3]
+        with self.ProgressCallBacker(self, description, progress_callback, progress_callback_n_instructions):
+            yield self.__conn.cursor()
 
     @contextmanager
     def temp_transaction(self, description=None, progress_callback=None, progress_callback_n_instructions=50*1024*1024):
         """ returns a cursor for working with CREATE TEMP TABLE.
             no commit is done
         """
-        try:
-            if not description:
-                description = inspect.stack()[2][3]
-            with self.ProgressCallBacker(self, description, progress_callback, progress_callback_n_instructions):
-                #time1 = time.perf_counter()
-                yield self.__conn.cursor()
-                #time2 = time.perf_counter()
-                #if self.print_execute_times:
-                #    if not description:
-                #        description = inspect.stack()[2][3]
-                #    print('DB temporary transaction %s took %0.3f ms' % (description, (time2-time1)*1000.0))
-                #self.statistics[description].add_instance((time2-time1)*1000.0)
-        except Exception as ex:
-            raise
+        if not description:
+            description = inspect.stack()[2][3]
+        with self.ProgressCallBacker(self, description, progress_callback, progress_callback_n_instructions):
+            yield self.__conn.cursor()
 
     def exec_script_file(self, file_name):
         with self.transaction("exec_script_file_"+file_name) as curs:
@@ -289,23 +267,20 @@ class DBMaster(object):
             return empty list of no values were found.
         """
         retVal = None
-        try:
-            if query_params is None:
-                query_params = {}
-            if self.print_execute_times:
-                description = inspect.stack()[1][3]
-            else:
-                description = None
-            with self.selection(description=description, progress_callback=progress_callback) as curs:
-                curs.execute(query_text, query_params)
-                one_result = curs.fetchone()
-                if one_result:
-                    if isinstance(one_result, (tuple, list)):
-                        retVal = one_result[0]
-                    else:
-                        retVal = one_result
-        except sqlite3.Error as ex:
-            raise
+        if query_params is None:
+            query_params = {}
+        if self.print_execute_times:
+            description = inspect.stack()[1][3]
+        else:
+            description = None
+        with self.selection(description=description, progress_callback=progress_callback) as curs:
+            curs.execute(query_text, query_params)
+            one_result = curs.fetchone()
+            if one_result:
+                if isinstance(one_result, (tuple, list)):
+                    retVal = one_result[0]
+                else:
+                    retVal = one_result
         return retVal
 
     def select_and_fetchall(self, query_text, query_params=None, progress_callback=None):
@@ -315,23 +290,20 @@ class DBMaster(object):
             return empty list of no values were found.
         """
         retVal = list()
-        try:
-            if query_params is None:
-                query_params = {}
-            if self.print_execute_times:
-                description = inspect.stack()[1][3]
-            else:
-                description = None
-            with self.selection(description=description, progress_callback=progress_callback) as curs:
-                curs.execute(query_text, query_params)
-                all_results = curs.fetchall()
-                if all_results:
-                    if len(all_results[0]) == 1:  # all_results is a list of one item lists, so flaten and return a list of items
-                        retVal.extend([res[0] for res in all_results])
-                    else:
-                        retVal.extend(all_results)
-        except sqlite3.Error as ex:
-            raise
+        if query_params is None:
+            query_params = {}
+        if self.print_execute_times:
+            description = inspect.stack()[1][3]
+        else:
+            description = None
+        with self.selection(description=description, progress_callback=progress_callback) as curs:
+            curs.execute(query_text, query_params)
+            all_results = curs.fetchall()
+            if all_results:
+                if len(all_results[0]) == 1:  # all_results is a list of one item lists, so flaten and return a list of items
+                    retVal.extend([res[0] for res in all_results])
+                else:
+                    retVal.extend(all_results)
         return retVal
 
     def lock_table(self, table_name):

--- a/db/indexItemTable.py
+++ b/db/indexItemTable.py
@@ -591,7 +591,7 @@ class IndexItemsTable(object):
                                     else:
                                         new_detail = (the_iid, the_iid, self.os_names_to_num[the_os], detail_name, value, tag)
                                         details.append(new_detail)
-        except Exception as ex:
+        except Exception:
             print(f"exception while reading details for iid {the_iid}")
             print(f"lines {the_node.start_mark.line} - {the_node.end_mark.line}")
             if detail_name:
@@ -615,11 +615,8 @@ class IndexItemsTable(object):
             template_match = self.template_re.match(IID)
             with kwargs['node-stack'](a_node[IID]):
                 if template_match:
-                    try:
-                        node = self.read_index_template_node(template_match, a_node[IID], **kwargs)
-                        self.read_index_node_helper(node, index_items, items_details, **kwargs)
-                    except:
-                        raise
+                    node = self.read_index_template_node(template_match, a_node[IID], **kwargs)
+                    self.read_index_node_helper(node, index_items, items_details, **kwargs)
                 else:
                     item, original_item_details = self.item_from_index_node(IID, a_node[IID], **kwargs)
                     index_items.append(item)
@@ -923,8 +920,6 @@ class IndexItemsTable(object):
         retVal.extend([mm[:num_fields_to_take] for mm in results])
         return retVal
 
-        return retVal
-
     def iids_from_guids(self, guid_list):
         translated_iids = list()
         orphaned_guids = list()
@@ -1005,19 +1000,6 @@ class IndexItemsTable(object):
         """
         retVal = self.db.select_and_fetchall(query_text, query_params={'look_for_status': look_for_status})
         return retVal
-
-    def change_status_of_iids_to_another_status__(self, old_status, new_status, iid_list):
-        if iid_list:
-            query_vars = '("' + '","'.join(iid_list) + '")'
-            query_text = f"""
-                UPDATE index_item_t
-                SET install_status={new_status}
-                WHERE install_status={old_status}
-                AND iid IN {query_vars}
-                AND ignore = 0
-              """
-            with self.db.transaction() as curs:
-                curs.execute(query_text)
 
     def change_status_of_iids_to_another_status(self, old_status, new_status, iid_list, progress_callback=None):
         if iid_list:
@@ -1398,8 +1380,8 @@ class IndexItemsTable(object):
             if direct_sync_indicator is not None:
                 try:
                     retVal = utils.str_to_bool_int(config_vars.resolve_str(direct_sync_indicator))
-                except:
-                    pass
+                except Exception as ex:
+                    log.debug("could not resolve direct_sync indicator %r: %s", direct_sync_indicator, ex)
             return retVal
         self.db.create_function("get_direct_sync_status_from_indicator", 1, _get_direct_sync_status_from_indicator)
 
@@ -1555,7 +1537,7 @@ class IndexItemsTable(object):
 
         self.db.exec_script_file("short-index.ddl")
 
-        query_text = f"""
+        query_text = """
                     -- select all rows that have some version
                     SELECT * FROM short_index_t
                     WHERE version_mac IS NOT NULL

--- a/pybatch/baseClasses.py
+++ b/pybatch/baseClasses.py
@@ -1,11 +1,3 @@
-import sys
-import abc
-import inspect
-from typing import Dict
-import time
-from contextlib import contextmanager
-from typing import List
-import logging
 import abc
 import inspect
 import logging

--- a/pybatch/batchCommandAccum.py
+++ b/pybatch/batchCommandAccum.py
@@ -66,20 +66,6 @@ class PythonBatchCommandAccum(PythonBatchCommandBase):
             counter += a_section.total_progress_count()
         return counter
 
-    def finalize_list_of_lines(self):
-        lines = list()
-        for section in PythonBatchCommandAccum.section_order:
-            # config_vars["CURRENT_PHASE"] = section
-            section_lines = self.instruction_lines[section]
-            if section_lines:
-                if section == "assign":
-                    section_lines.sort()
-                for section_line in section_lines:
-                    resolved_line = config_vars.resolve_str_to_list(section_line)
-                    lines.extend(resolved_line)
-                lines.append("")  # empty string will cause to emit new line
-        return lines
-
     def add(self, child_commands):
         assert not self.in_sub_accum, "PythonBatchCommandAccum.add: should not be called while sub_accum is in context"
         self.sections[self.current_section].add(child_commands)

--- a/pybatch/copyBatchCommands.py
+++ b/pybatch/copyBatchCommands.py
@@ -386,16 +386,16 @@ no_flags_patterns: if a file matching one of these patterns exists in the destin
         try:
             last_src_path = self.last_src
             last_src_mode = utils.unix_permissions_to_str(last_src_path.lstat().st_mode)
-        except:
-            pass
+        except Exception as ex:
+            log.debug(f"could not get mode for last_src {last_src_path}: {ex}")
 
         last_dst_path = "unknown"
         last_dst_mode = "unknown"
         try:
             last_dst_path = self.last_dst
             last_dst_mode = utils.unix_permissions_to_str(last_dst_path.lstat().st_mode)
-        except:
-            pass
+        except Exception as ex:
+            log.debug(f"could not get mode for last_dst {last_dst_path}: {ex}")
 
         self._error_dict.update(
             {'last_src': {"path": os.fspath(last_src_path), "mode": last_src_mode},
@@ -682,8 +682,8 @@ class ShouldCopySource(RsyncClone):
                 if top_src.stat().st_ino == top_trg.stat().st_ino:
                     self.reason_not_to_copy = f"source and target have same inode"  # type: ignore
                     should_copy = False
-        except:  # if checking failed for any reason, just return True
-            pass
+        except Exception as ex:  # if checking failed for any reason, just return True
+            log.debug(f"ShouldCopySource check failed, will copy: {ex}")
 
         if not should_copy:
             raise PythonBatchCommandBase.SkipActionException()

--- a/pybatch/fileSystemBatchCommands.py
+++ b/pybatch/fileSystemBatchCommands.py
@@ -343,8 +343,8 @@ class ChFlags(RunProcessBase):
                         dir_listing = utils.single_disk_item_listing(_error, output_format="json")
                         list_of_listings.append(dir_listing)
                     self._error_dict["ls of problem files"] = list_of_listings
-        except:  # populating the error dict should continue, even if error_dict_self failed
-            pass
+        except Exception as ex:  # populating the error dict should continue, even if error_dict_self failed
+            log.debug(f"error_dict_self failed: {ex}")
 
     def __call__(self, *args, **kwargs):
         if sys.platform in self.flags_dict:  # avoid linux for the time being
@@ -465,8 +465,8 @@ class Chown(RunProcessBase, call__call__=True):
             else:
                 dir_listing = utils.single_disk_item_listing(self.path, output_format="json")
                 self._error_dict["ls of problem file"] = dir_listing
-        except:  # populating the error dict should continue, even if error_dict_self failed
-            pass
+        except Exception as ex:  # populating the error dict should continue, even if error_dict_self failed
+            log.debug(f"error_dict_self failed: {ex}")
 
 
 class Chmod(RunProcessBase):
@@ -671,8 +671,8 @@ class Chmod(RunProcessBase):
                 dir_listing = utils.single_disk_item_listing(self.path, output_format="json")
                 self._error_dict["ls of problem file"] = dir_listing
 
-        except:  # populating the error dict should continue, even if error_dict_self failed
-            pass
+        except Exception as ex:  # populating the error dict should continue, even if error_dict_self failed
+            log.debug(f"error_dict_self failed: {ex}")
 
 
 class ChmodAndChown(PythonBatchCommandBase):

--- a/pybatch/info_mapBatchCommands.py
+++ b/pybatch/info_mapBatchCommands.py
@@ -1,16 +1,9 @@
-from http.cookies import SimpleCookie
-from requests.cookies import cookiejar_from_dict
-from typing import List, Any
+from typing import List
 import os
 import sys
-import stat
-import zlib
 from collections import defaultdict
 from pathlib import Path
 import logging
-import requests
-import time
-import datetime
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +18,6 @@ from .fileSystemBatchCommands import Chmod
 from .wtarBatchCommands import Wzip
 from .copyBatchCommands import CopyFileToFile
 from .downloadBatchCommands import DownloadFileAndCheckChecksum, DownloadManager
-from svnTree.svnTable import SVNTable
 
 from db import DBManager
 

--- a/pybatch/new_batchCommands.py
+++ b/pybatch/new_batchCommands.py
@@ -1,33 +1,8 @@
-from typing import List, Any, Union
-import tempfile
-import stat
-import tarfile
-from collections import OrderedDict
+from typing import List, Union
 from configVar import config_vars
-import collections
-import zlib
 
 from .fileSystemBatchCommands import *
 from .copyBatchCommands import *
-
-"""
-class Dummy(PythonBatchCommandBase):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-
-    def __repr__(self) -> str:
-        the_repr = f'''{self.__class__.__name__}()'''
-        return the_repr
-
-    def progress_msg_self(self) -> str:
-        return f''''''
-
-    def __call__(self, *args, **kwargs) -> None:
-        pass
-    
-    def error_dict_self(self, exc_val):
-        pass
-"""
 
 
 class CopyDirToDirEx(PythonBatchCommandBase):

--- a/pybatch/removeBatchCommands.py
+++ b/pybatch/removeBatchCommands.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import shutil
 import re
 import sys
@@ -34,8 +33,8 @@ class RmFile(PythonBatchCommandBase, kwargs_defaults={'resolve_path': True}):
         try:
             file_listing = utils.single_disk_item_listing(self.path, output_format="json")
             self._error_dict["ls"] = file_listing
-        except:  # populating the error dict should continue, even if error_dict_self failed
-            pass
+        except Exception as ex:  # populating the error dict should continue, even if error_dict_self failed
+            log.debug(f"error_dict_self failed: {ex}")
 
     def __call__(self, *args, **kwargs):
         PythonBatchCommandBase.__call__(self, *args, **kwargs)
@@ -88,8 +87,8 @@ class RmDir(PythonBatchCommandBase, kwargs_defaults={'resolve_path': True}):
         try:
             file_listing = utils.single_disk_item_listing(self.path, output_format="json")
             self._error_dict["ls"] = file_listing
-        except:  # populating the error dict should continue, even if error_dict_self failed
-            pass
+        except Exception as ex:  # populating the error dict should continue, even if error_dict_self failed
+            log.debug(f"error_dict_self failed: {ex}")
 
     def __call__(self, *args, **kwargs):
         PythonBatchCommandBase.__call__(self, *args, **kwargs)
@@ -238,7 +237,7 @@ class RmGlob(PythonBatchCommandBase):
     def __call__(self, *args, **kwargs):
         PythonBatchCommandBase.__call__(self, *args, **kwargs)
         if self.pattern is None:
-            log.wanging(f"skip RmGlob of '{self.path_to_folder}' because pattern is None")
+            log.warning(f"skip RmGlob of '{self.path_to_folder}' because pattern is None")
         else:
             folder = utils.ExpandAndResolvePath(self.path_to_folder)
             list_to_remove = folder.glob(self.pattern)
@@ -276,10 +275,6 @@ class RmGlobs(PythonBatchCommandBase):
                 with RmFileOrDir(item, own_progress_count=0) as rfod:
                     rfod()
 
-
-#def unnamed__init__param(self, value):
-#def named__init__param(self, name, value):
-#def optional_named__init__param(self, name, value, default=None):
 
 class RmDirContents(PythonBatchCommandBase):
     """ remove all items in a folder (unless item is excluded)

--- a/pybatch/subprocessBatchCommands.py
+++ b/pybatch/subprocessBatchCommands.py
@@ -427,7 +427,7 @@ class Subprocess(RunProcessBase):
                 else:
                     all_args.append(self.named__init__param("ignore_specific_exit_codes", self.ignore_specific_exit_codes))
         except TypeError as te:
-            pass
+            log.debug(f"Subprocess.repr_own_args failed: {te}")
 
     def progress_msg_self(self):
         if self.message:

--- a/pyinstl/connectionBase.py
+++ b/pyinstl/connectionBase.py
@@ -3,7 +3,6 @@
 
 import abc
 import json
-import urllib.error
 import urllib.parse
 
 import requests
@@ -15,11 +14,6 @@ log = logging.getLogger()
 from typing import Dict
 
 have_boto = False
-# try:
-#     import boto3
-#     have_boto = True
-# except Exception:
-#     pass
 
 
 class ConnectionBase(object):

--- a/pyinstl/installItemGraph.py
+++ b/pyinstl/installItemGraph.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3.12
 
 import utils
-from configVar import config_vars
 
-try:
-    import networkx as nx
-except ImportError as IE:
-    raise IE
+import networkx as nx
 
 
 def create_dependencies_graph(items_table):
@@ -21,7 +17,7 @@ def create_inheritItem_graph(items_table):
     retVal = nx.DiGraph()
     for iid in items_table.get_all_iids():
         for dependant in items_table.get_resolved_details_for_iid(iid, "inherit"):
-                retVal.add_edge(iid, dependant)
+            retVal.add_edge(iid, dependant)
     return retVal
 
 

--- a/pyinstl/instlClientRemove.py
+++ b/pyinstl/instlClientRemove.py
@@ -57,7 +57,6 @@ class InstlClientRemove(InstlClient):
                         sources_for_iid = self.items_table.get_sources_for_iid(IID)
                         resolved_sources_for_iid = [(config_vars.resolve_str(s[0]), s[1]) for s in sources_for_iid]
                         for source in resolved_sources_for_iid:
-                            _, source_leaf = os.path.split(source[0])
                             iid_accum_transaction += self.accumulate_actions_for_iid(iid=IID, detail_name="pre_remove_item")
                             iid_accum_transaction += self.create_remove_instructions_for_source(IID, folder_name, source)
                             iid_accum_transaction += self.accumulate_actions_for_iid(iid=IID, detail_name="post_remove_item")
@@ -94,7 +93,7 @@ class InstlClientRemove(InstlClient):
                     remove_items = self.info_map_table.get_items_in_dir(dir_path=source_path, immediate_children_only=True)
                     remove_paths = utils.original_names_from_wtars_names(item.path for item in remove_items)
                     for remove_path in remove_paths:
-                        base_, leaf = os.path.split(remove_path)
+                        _, leaf = os.path.split(remove_path)
                         full_path_to_remove = os.path.normpath(os.path.join(folder, leaf))
                         retVal += RmFileOrDir(full_path_to_remove)
         else:

--- a/pyinstl/instlClientReport.py
+++ b/pyinstl/instlClientReport.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3.12
 
 
-import os
 import io
 import json
-from collections import defaultdict
 
 import aYaml
 from configVar import config_vars
-from pybatch import ShortIndexYamlCreator
 from .instlClient import InstlClient
 import utils
 

--- a/pyinstl/instlClientSync.py
+++ b/pyinstl/instlClientSync.py
@@ -3,7 +3,6 @@
 
 from configVar import config_vars
 from .instlClient import InstlClient
-from pybatch import Stage
 
 
 class InstlClientSync(InstlClient):

--- a/pyinstl/instlCommandList.py
+++ b/pyinstl/instlCommandList.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import shlex
 
 from pyinstl.instlMisc import InstlMisc
@@ -27,7 +26,7 @@ class CommandListRunner(object):
                 self.do_forked_command(argv)
 
             for child_pid in self.child_pids:
-                wait_val = os.waitpid(child_pid, 0)
+                os.waitpid(child_pid, 0)
             self.instance.batch_accum += self.instance.platform_helper.echo(f"Running {len(command_list)} commands in parallel done")
         else:
             self.instance.batch_accum += self.instance.platform_helper.echo(f"Running {len(command_list)} commands one by one from {command_list_leaf}")
@@ -56,32 +55,12 @@ class CommandListRunner(object):
             self.instance.do_command()
 
     def do_forked_command(self, argv):
-        #rpipe, wpipe = os.pipe()
         new_pid = os.fork()
         if 0 == new_pid:
-            #os.close(rpipe)
-            #os.dup2(wpipe, sys.stdout.fileno())
-            #os.dup2(wpipe, sys.stderr.fileno())
-            #os.close(wpipe)
             self.run_one_command(argv)
             exit(0)
         else:
             self.child_pids.append(new_pid)
-"""
-rpipe, wpipe = os.pipe()
-
-pid = os.fork()
-if pid == -1:
-    raise TestError("Failed to fork() in prepare_test_dir")
-
-if pid == 0:
-    # Child -- do the copy, print log to pipe and exit
-    try:
-        os.close(rpipe)
-        os.dup2(wpipe, sys.stdout.fileno())
-        os.dup2(wpipe, sys.stderr.fileno())
-        os.close(wpipe)
-"""
 
 
 def run_commands_from_file(initial_vars, options):

--- a/pyinstl/instlInstanceSyncBase.py
+++ b/pyinstl/instlInstanceSyncBase.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3.12
 
-import sys
 import os
 import abc
 import logging

--- a/pyinstl/instl_main.py
+++ b/pyinstl/instl_main.py
@@ -10,15 +10,11 @@ import logging
 import platform
 from pathlib import Path
 from functools import lru_cache
-import json
 from configVar import config_vars
 from pybatch import PythonBatchRuntime
 from pyinstl.cmdOptions import CommandLineOptions, read_command_line_options
 
-from pyinstl.instlException import InstlException
 import utils
-
-#utils.set_max_open_files(2048)
 
 from utils.log_utils import config_logger
 
@@ -108,8 +104,8 @@ class InvocationReporter(PythonBatchRuntime):
 
     def enter_self(self) -> None:
         try:
-            vendor_name = os.environ.setdefault("VENDOR_NAME", "Waves Audio")
-            app_name = os.environ.setdefault("APPLICATION_NAME", "Waves Central")
+            os.environ.setdefault("VENDOR_NAME", "Waves Audio")
+            os.environ.setdefault("APPLICATION_NAME", "Waves Central")
             config_logger(argv=self.argv, config_vars=config_vars)
             log.debug(f"===== {self.random_invocation_name} =====")
             log.debug(f"Start: {self.start_time}")
@@ -119,7 +115,6 @@ class InvocationReporter(PythonBatchRuntime):
             log.warning(f'instl log file report start failed - {e}')
 
     def exit_self(self, exit_return) -> None:
-        # self.doing = self.doing if self.doing else utils.get_latest_action_from_stack()
         try:
             end_time = datetime.datetime.now()
             log.debug(f"Run time: {self.command_time_sec}")

--- a/svnTree/svnTable.py
+++ b/svnTree/svnTable.py
@@ -4,7 +4,6 @@
 import os
 import re
 import logging
-from pathlib import Path
 
 log = logging.getLogger()
 
@@ -393,7 +392,7 @@ class SVNTable(object):
 
                     row_data.extend((0, 0, ""))  # required, need_download, extra_props
                     return row_data
-                except KeyError as unused_ke:
+                except KeyError:
                     log.error(f"""SVNTable.read_from_svn_info Error: line: {line_num}  record: {record}""")
                     raise
 
@@ -822,12 +821,12 @@ class SVNTable(object):
             #    The Unicode max code point (0x10FFFF) creates a tight upper bound for prefix matching,
             #    allowing the B-tree index to efficiently find all paths starting with the prefix
 
-            update_paths_exact_q = f"""
+            update_paths_exact_q = """
                     UPDATE cache_folder_file_paths_t AS c
                     SET remove = 0
                     WHERE EXISTS (SELECT 1 FROM do_not_remove_file_paths_exact_t d WHERE d.path = c.path);
                     """
-            update_paths_prefix_q = f"""
+            update_paths_prefix_q = """
                     UPDATE cache_folder_file_paths_t AS c
                     SET remove = 0
                     WHERE EXISTS (
@@ -877,8 +876,6 @@ class SVNTable(object):
         if what not in ("any", "file", "dir"):
             raise ValueError(f"{what} not a valid filter for get_item")
 
-        want_file = what in ("any", "file")
-        want_dir = what in ("any", "dir")
         extra_condition = {"file": "AND fileFlag == 1", "dir": "AND fileFlag == 0"}.get(what, "")
         with self.db.selection() as curs:
             curs.execute(f"""
@@ -900,8 +897,6 @@ class SVNTable(object):
         if what not in ("any", "file", "dir"):
             raise ValueError(f"{what} not a valid filter for get_item")
 
-        want_file = what in ("any", "file")
-        want_dir = what in ("any", "dir")
         extra_condition = {"file": "AND fileFlag == 1", "dir": "AND fileFlag == 0"}.get(what, "")
         with self.db.selection() as curs:
             curs.execute(f"""
@@ -1611,7 +1606,7 @@ class SVNTable(object):
                              range(0, len(zero_pad_repo_rev), self.num_digits_per_folder_repo_rev_hierarchy)]
                 retVal = "/".join(by_groups)
         except Exception as ex:
-            pass
+            log.debug("repo_rev_to_folder_hierarchy(%r) failed, using flat value: %s", repo_rev, ex)
         return retVal
 
     def get_sync_url_for_file_item(self, file_item: SVNRow):

--- a/utils/dockutil.py
+++ b/utils/dockutil.py
@@ -19,7 +19,7 @@
 # Possible future enhancements
 # tie in with application identifier codes for locating apps and replacing them in the dock with newer versions?
 
-import sys, plistlib, subprocess, os, getopt, re, pipes, tempfile, pwd, logging
+import sys, plistlib, subprocess, os, getopt, re, shlex, tempfile, pwd, logging
 import platform
 
 import utils
@@ -271,7 +271,7 @@ def dock_util(args):
         if os.path.exists(os.path.expanduser(plist_path)):
             plist_path = os.path.expanduser(plist_path)
             plist_path = os.path.abspath(plist_path)
-            plist_path = pipes.quote(plist_path)
+            plist_path = shlex.quote(plist_path)
         else:
             print(plist_path, 'does not seem to be a home directory or a dock plist')
             return 1
@@ -457,7 +457,6 @@ def moveItem(pl, move_label=None, position=None, before_item=None, after_item=No
         # loop over the items looking for the item label
         for item_offset in range(len(pl[section])):
             if pl[section][item_offset]['tile-data']['file-label'] == move_label:
-                item_found = True
                 verboseOutput('found', move_label)
                 # make a copy of the found dock entry
                 item_to_move = pl[section][item_offset]

--- a/utils/email_utils.py
+++ b/utils/email_utils.py
@@ -1,10 +1,6 @@
 # Note: this file was renamed email_utils because when it was named email.py python module importer sometimes gets confused with e builtin email module
 
-import os
-import re
 import smtplib
-from email import encoders
-from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 

--- a/utils/extract_info.py
+++ b/utils/extract_info.py
@@ -7,9 +7,12 @@ import subprocess
 import xml.etree.ElementTree as ET
 import codecs
 import re
+import logging
 from pathlib import Path
 
 import utils
+
+log = logging.getLogger()
 
 if sys.platform == 'win32':
     import win32api
@@ -130,7 +133,7 @@ def Mac_bundle(in_os, in_path):
                 if version or guid:
                     retVal = (in_path, version, guid)
     except Exception as ex:
-        pass
+        log.debug(f"failed to extract info from {in_path}: {ex}")
     return retVal
 
 

--- a/utils/files.py
+++ b/utils/files.py
@@ -32,7 +32,7 @@ def set_active_user_or_group_config_var_callback(config_var_name, config_var_val
         elif config_var_name == "ACTING_GID":
             global global_acting_gid
             global_acting_gid = int(config_var_value)
-    except ValueError as ex:
+    except ValueError:
         # if value is not int it will not be assigned to global_acting_uid/global_acting_gid
         pass
 
@@ -52,7 +52,7 @@ def utf8_open_for_read(*args, **kwargs) -> TextIO:
         try:
             retVal = open(*args, encoding='utf-8', errors='backslashreplace', **kwargs)
             break
-        except PermissionError as per_err:
+        except PermissionError:
             if _try == 0:
                 the_path = args[0]
                 from pybatch import FixAllPermissions
@@ -60,8 +60,6 @@ def utf8_open_for_read(*args, **kwargs) -> TextIO:
                     fixer()
             else:
                 raise
-        except Exception:
-            raise
     return retVal
 
 
@@ -432,7 +430,7 @@ def safe_remove_file(path_to_file, ignore_errors=True):
         os.remove(path_to_file)
     except FileNotFoundError:  # os.remove raises is the file does not exists
         pass
-    except Exception as ex:
+    except Exception:
         if not ignore_errors:
             raise
 
@@ -442,7 +440,7 @@ def safe_remove_folder(path_to_folder, ignore_errors=True):
         shutil.rmtree(path_to_folder, ignore_errors=ignore_errors)
     except FileNotFoundError:
         pass
-    except Exception as ex:
+    except Exception:
         if not ignore_errors:
             raise
 
@@ -459,7 +457,7 @@ def safe_remove_file_system_object(path_to_file_system_object, followlinks=False
             safe_remove_folder(path_to_file_system_object, ignore_errors)
         elif os.path.isfile(path_to_file_system_object):
             safe_remove_file(path_to_file_system_object, ignore_errors)
-    except Exception as ex:
+    except Exception:
         if not ignore_errors:
             raise
 
@@ -489,6 +487,7 @@ def excluded_walk(root_to_walk, file_exclude_regex=None, dir_exclude_regex=None,
 def get_disk_free_space(in_path):
     retVal = 0
     if 'Win' in utils.get_current_os_names():
+        import win32file
         secsPerCluster, bytesPerSec, nFreeCluster, totCluster = win32file.GetDiskFreeSpace(in_path)
         retVal = secsPerCluster * bytesPerSec * nFreeCluster
     elif 'Mac' in utils.get_current_os_names():
@@ -525,8 +524,8 @@ def smart_copy_file(source_path, destination_path):
     except Exception:
         try:
             shutil.copy2(s, d)
-        except Exception:
-            pass
+        except Exception as ex:
+            log.debug(f"smart_copy_file failed to copy {s} to {d}: {ex}")
 
 
 def find_split_files(first_file: Path):
@@ -650,7 +649,7 @@ def get_main_drive_name():
             import win32api
             retVal = win32api.GetVolumeInformation("C:\\")[0]
     except:
-        pass
+        log.debug("get_main_drive_name failed", exc_info=True)
     return retVal
 
 
@@ -707,7 +706,7 @@ def safe_getcwd(return_on_error="os.getcwd() failed", ignore_exceptions=True):
     retVal = None
     try:
         retVal = os.getcwd()
-    except FileNotFoundError as fnf:
+    except FileNotFoundError:
         if ignore_exceptions:
             if return_on_error:
                 retVal = return_on_error

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -87,7 +87,6 @@ class PerLevelFormatter(logging.Formatter):
 def setup_file_logging(log_file_path, level=logging.DEBUG, rotate=True, config_vars=None):
     """ Setting up a file logging handler """
     log_file_path = Path(log_file_path).resolve()
-    log_file_folder = log_file_path.parent
     os.makedirs(log_file_path.parent, exist_ok=True)
     top_logger = logging.getLogger()
 
@@ -96,7 +95,7 @@ def setup_file_logging(log_file_path, level=logging.DEBUG, rotate=True, config_v
     else:
         fileLogHandler =  logging.FileHandler(log_file_path, encoding='utf-8')
     fileLogHandler.setLevel(level)
-    fileLogHandler.set_name(f"(log_file_name)_log_handler")
+    fileLogHandler.set_name("(log_file_name)_log_handler")
     formatter = PerLevelFormatter(format_per_level, fmt=format_per_level[logging.CRITICAL], datefmt='%Y-%m-%d_%H:%M:%S', style='%')
 
     fileLogHandler.setFormatter(formatter)

--- a/utils/ls.py
+++ b/utils/ls.py
@@ -8,7 +8,7 @@ import stat
 import json
 import tarfile
 import re
-from pathlib import Path, PurePath
+from pathlib import PurePath
 
 import utils
 
@@ -356,7 +356,7 @@ def win_item_ls(the_path, ls_format, root_folder=None):
                         owner_sid = sd.GetSecurityDescriptorOwner()
                         name, domain, __type = win32security.LookupAccountSid(None, owner_sid)
                         the_parts[format_char] = domain+"\\"+name  # user
-                    except Exception as ex:  # we sometimes get exception: 'LookupAccountSid, No mapping between account names and security IDs was done.'
+                    except Exception:  # we sometimes get exception: 'LookupAccountSid, No mapping between account names and security IDs was done.'
                         the_parts[format_char] = "Unknown user"
 
                 case 'G':
@@ -365,7 +365,7 @@ def win_item_ls(the_path, ls_format, root_folder=None):
                         owner_sid = sd.GetSecurityDescriptorGroup()
                         name, domain, __type = win32security.LookupAccountSid(None, owner_sid)
                         the_parts[format_char] = domain+"\\"+name  # group
-                    except Exception as ex:  # we sometimes get exception: 'LookupAccountSid, No mapping between account names and security IDs was done.'
+                    except Exception:  # we sometimes get exception: 'LookupAccountSid, No mapping between account names and security IDs was done.'
                         the_parts[format_char] = "Unknown group"
 
                 case 'C':

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -6,7 +6,6 @@ import os
 import platform
 import re
 import hashlib
-import base64
 import collections
 import subprocess
 import numbers
@@ -316,7 +315,7 @@ def check_file_checksum(file_path, expected_checksum):
             with open(file_path, "rb") as rfd:
                 retVal = check_buffer_checksum(rfd.read(), expected_checksum)
         except:
-            pass
+            log.debug("check_file_checksum failed for %s", file_path, exc_info=True)
     return retVal
 
 
@@ -706,8 +705,8 @@ def get_wtar_total_checksum(wtar_file_path):
             with utils.MultiFileReader("br", wtar_file_paths) as fd:
                 with tarfile.open(fileobj=fd) as tar:
                     tar_total_checksum = tar.pax_headers.get("total_checksum")
-    except Exception as ex:
-        pass  # return None if there was exception from any reason
+    except Exception as ex:  # return None if there was exception from any reason
+        log.debug(f"get_wtar_total_checksum failed for {wtar_file_path}: {ex}")
     return tar_total_checksum
 
 

--- a/utils/str_utils.py
+++ b/utils/str_utils.py
@@ -39,36 +39,10 @@ def quoteme_single_list_for_sql(to_quote_list):
     return "".join(("('", "','".join(to_quote_list), "')"))
 
 
-#no_need_for_raw_re = re.compile('^[a-zA-Z0-9_\-\./${}%:+ ]+$')
 escape_quotations_re = re.compile("['\"\\\\]")
 def escape_quotations(simple_string):
     """ escape the characters ', '. \\ """
     retVal = escape_quotations_re.sub(lambda match_obj: r'\\'+match_obj.group(0), simple_string)
-    return retVal
-
-
-def quoteme_raw_string(simple_string):
-    assert isinstance(simple_string, str), f"{simple_string} is not of type str"
-
-    if not simple_string:
-        retVal = 'r""'
-
-    else:
-        simple_string = os.fspath(simple_string)
-
-        possible_quote_marks = ('"', "'", '"""', "'''")
-        if "\n" in simple_string:  # multiline strings need triple quotation
-            possible_quote_marks = ('"""', "'''")
-
-        for quote_mark in possible_quote_marks:
-            # 1st priority is to create a raw string. Strings that end with the quotation mark or with \ cannot be raw.
-            if quote_mark not in simple_string and quote_mark[-1] != simple_string[-1] and simple_string[-1] != '\\':
-                retVal = "".join(('r', quote_mark, simple_string, quote_mark))
-                break
-        else:
-            # if all possible quotations marks are present in the string - do proper escaping and return non-raw string
-            retVal = "".join(('"', escape_quotations(simple_string), '"'))
-
     return retVal
 
 
@@ -251,9 +225,6 @@ def str_to_float(the_str):
 
 
 if __name__ == "__main__":
-    #print(quoteme_raw_string(r'''"$(LOCAL_REPO_SYNC_DIR)/Mac/Utilities/plist/plist_creator.sh" "$(__Plist_for_native_instruments_1__)"'''))
-    #print(quoteme_raw_string("""single-single(') triple-single(''') single-double(") single-triple(\"\"\")"""))
-
     rere = re.compile(r"""['"\\]""")
     s = r"""A"B'C'''D'\\EFG"""
     rs = rere.sub(lambda matchobj: '\\'+matchobj.group(0), s)


### PR DESCRIPTION
Housekeeping across `utils`, `db`/`svnTree`, pyinstl core, `pybatch` and `aYaml`. No behaviour changes except the two fixes below — the rest is code that could not run, imports nothing referenced, or exception handlers that discarded the reason they fired.

**28 files, +99 / −287.** Independent of everything else I have queued: it can go before or after, in either order.

## Two bugs, both still live on `master3`

**`RmGlob.__call__` calls `log.wanging`** when its pattern is `None`. That raises `AttributeError` instead of logging the skip — so the one path meant to be a graceful no-op is the one that throws.

```
$ git show master3:pybatch/removeBatchCommands.py | grep wanging
log.wanging(f"skip RmGlob of '{self.path_to_folder}' because pattern is None")
```

**`utils.str_utils` defines `quoteme_raw_string` twice**, and the definitions had diverged. The second shadows the first, so the first has never run — but it is the one you find when you go looking, and `pybatch.conditionalBatchCommands` uses this function to build its `repr`. The dead copy is gone; `test_pybatch_serialization_golden` pins that the surviving one produces the same output.

## The rest, by kind

- **`try`/`except` blocks whose handler was a bare `raise`** — three in `dbMaster`. They changed nothing and hid the flow.
- **`except: pass` → `except Exception as ex: log.debug(...)`.** Still swallowed, now diagnosable. Most guard error-report enrichment, where continuing really is right — but a silent failure there means the error dict is quietly incomplete.
- **`except SomeError as ex` where `ex` was never read** — binding dropped.
- Unused imports, unused locals, commented-out blocks, one indentation fix, and a `try`/`import`/`raise` wrapper around `networkx` that did nothing an `import` does not.
- `utils/dockutil.py` moves off the `pipes` module, which Python 3.13 removed.

## Verification

Per module, each in its own process (whole-tree discovery is unreliable — `config_vars` is a process-wide singleton and tests leak state into each other). **Thirteen modules against `master3`: identical failure sets.**

`test_subprocessBatchCommands` reports one count apart between runs on both trees — it runs real subprocesses and is mildly flaky. The failing tests are the same four either way.

Not claimed: a green suite. It is not green here and was not green on `master3`.
