### PR TITLE
Report what the install is doing, and unwtar in parallel

### DIFF
--- a/configVar/__init__.py
+++ b/configVar/__init__.py
@@ -2,4 +2,5 @@
 from .configVarStack import config_vars
 from .configVarStack import private_config_vars
 from .configVarYamlReader import ConfigVarYamlReader, eval_conditional, smart_resolve_yaml
+from .accessors import config_var_str, config_var_bool, config_var_int, config_var_list
 var_stack = config_vars  # for backward compatibility of scripts executed with "exec" command

--- a/configVar/accessors.py
+++ b/configVar/accessors.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3.12
+
+
+"""
+    Copyright (c) 2012, Shai Shasag
+    All rights reserved.
+    Licensed under BSD 3 clause license, see LICENSE file for details.
+
+    Typed readers for OPTIONAL config vars: a key that was never defined reads as
+    its default rather than raising. The download settings (the DOWNLOAD_* family)
+    are all optional and mostly absent, so their readers would otherwise each need
+    a membership test and a conversion at every call site.
+
+    For keys instl always defines, read config_vars directly - that is the house
+    idiom and these add nothing to it.
+"""
+
+from typing import List
+
+from .configVarStack import config_vars
+
+
+def config_var_str(name: str, default=None):
+    """Return `name` as a non-empty string, or `default`."""
+    if name not in config_vars:
+        return default
+    try:
+        value = config_vars[name].str()
+    except Exception:
+        value = str(config_vars[name])
+    return value if value else default
+
+
+def config_var_bool(name: str, default: bool = False) -> bool:
+    """Return `name` as a bool, or `default`. "yes"/"true"/"1" are true, "no"/"false"/"0" false."""
+    if name not in config_vars:
+        return default
+    return config_vars[name].bool()
+
+
+def config_var_int(name: str, default: int = 0) -> int:
+    """Return `name` as an int, or `default` if unset or not a number."""
+    if name not in config_vars:
+        return default
+    try:
+        return int(config_vars[name].str())
+    except (ValueError, TypeError):
+        return default
+
+
+def config_var_list(name: str) -> List[str]:
+    """Return `name` as a list of non-empty, stripped strings ([] when unset).
+
+    A single value containing commas is split on them, so a setting can be written
+    either as a yaml list or as one "a, b, c" string.
+    """
+    if name not in config_vars:
+        return []
+    values = config_vars[name].list()
+    if len(values) == 1:
+        value = str(values[0])
+        if "," in value:
+            values = [part.strip() for part in value.split(",")]
+    return [str(value).strip() for value in values if str(value).strip()]

--- a/defaults/InstlClient.yaml
+++ b/defaults/InstlClient.yaml
@@ -88,6 +88,13 @@ CONFIG_VARS_FOR_ERROR_REPORT:
     - S3_BUCKET_NAME
     - REPO_NAME
 
+# Parallel unwtar: extract wtar archives across a process pool instead of one at a
+# time - decompression is CPU-bound and was fully serial. A kill switch, so the
+# stage can fall back to the serial path if a problem surfaces.
+# DOWNLOAD_PARALLEL_WORKERS = 0 means "auto" (os.cpu_count()).
+DOWNLOAD_PARALLEL_UNWTAR: yes
+DOWNLOAD_PARALLEL_WORKERS: 0
+
 --- !define_Mac
 REMOVE_EMPTY_FOLDERS_IGNORE_FILES:
     - .DS_Store

--- a/pybatch/__init__.py
+++ b/pybatch/__init__.py
@@ -9,7 +9,7 @@ from .copyBatchCommands import CopyDirContentsToDir, CopyDirToDir, CopyFileToDir
 from .downloadBatchCommands import DownloadFileAndCheckChecksum, DownloadManager
 from .fileSystemBatchCommands import AppendFileToFile, Cd, ChFlags, Chmod, Chown, MakeDir, MakeRandomDirs, \
     MakeRandomDataFile, touch, Touch, Unlock, Ls, FileSizes, SplitFile, FixAllPermissions, Glober
-from .info_mapBatchCommands import CheckDownloadFolderChecksum, SetExecPermissionsInSyncFolder, CreateSyncFolders, \
+from .info_mapBatchCommands import CheckDownloadFolderChecksum, ReportDownloadState, SetExecPermissionsInSyncFolder, CreateSyncFolders, \
     InfoMapFullWriter, InfoMapSplitWriter, SetBaseRevision, IndexYamlReader, CopySpecificRepoRev, CreateRepoRevFile, \
     ShortIndexYamlCreator
 from .removeBatchCommands import RmDir, RmFile, RmFileOrDir, RemoveEmptyFolders, RmGlob, RmGlobs, RmDirContents

--- a/pybatch/copyBatchCommands.py
+++ b/pybatch/copyBatchCommands.py
@@ -309,6 +309,15 @@ no_flags_patterns: if a file matching one of these patterns exists in the destin
                 raise
         else:
             self.statistics['skipped_files'] += 1
+        # Report this file's bytes toward the copy-phase
+        # progress. No-op unless an install copy phase is armed; reported for
+        # copied, hard-linked AND skipped files because the planned total counts
+        # every source file. Best-effort -- never break a copy.
+        try:
+            from pybatch.copyPhaseProgress import report_copy_bytes
+            report_copy_bytes(src.stat().st_size)
+        except Exception:
+            pass
         return dst
 
     def copy_file_to_dir(self, src: Path, dst: Path, follow_symlinks=True):
@@ -386,16 +395,16 @@ no_flags_patterns: if a file matching one of these patterns exists in the destin
         try:
             last_src_path = self.last_src
             last_src_mode = utils.unix_permissions_to_str(last_src_path.lstat().st_mode)
-        except:
-            pass
+        except Exception as ex:
+            log.debug(f"could not get mode for last_src {last_src_path}: {ex}")
 
         last_dst_path = "unknown"
         last_dst_mode = "unknown"
         try:
             last_dst_path = self.last_dst
             last_dst_mode = utils.unix_permissions_to_str(last_dst_path.lstat().st_mode)
-        except:
-            pass
+        except Exception as ex:
+            log.debug(f"could not get mode for last_dst {last_dst_path}: {ex}")
 
         self._error_dict.update(
             {'last_src': {"path": os.fspath(last_src_path), "mode": last_src_mode},
@@ -682,8 +691,8 @@ class ShouldCopySource(RsyncClone):
                 if top_src.stat().st_ino == top_trg.stat().st_ino:
                     self.reason_not_to_copy = f"source and target have same inode"  # type: ignore
                     should_copy = False
-        except:  # if checking failed for any reason, just return True
-            pass
+        except Exception as ex:  # if checking failed for any reason, just return True
+            log.debug(f"ShouldCopySource check failed, will copy: {ex}")
 
         if not should_copy:
             raise PythonBatchCommandBase.SkipActionException()

--- a/pybatch/copyPhaseProgress.py
+++ b/pybatch/copyPhaseProgress.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3.12
+
+"""Process-global copy/install-phase byte-progress accumulator.
+
+The copy phase is a sequence of many discrete pybatch commands (CopyFileToDir,
+CopyDirToDir, Unwtar, ...), so unlike download or verify there is no single loop
+to tick from. The copy/unwtar commands report the bytes they handle here, and
+this module emits throttled ``copying`` ``session_state`` ticks carrying
+``phaseBytesDone`` / ``phaseBytesPlanned``, which Central needs for a
+determinate bar through the install tail.
+
+The counters below are module state, so reporting MUST happen on the main
+process - bytes reported from a worker process accumulate in that process and
+are lost.
+
+``report_copy_bytes`` is a no-op until ``begin_copy_phase`` has set a positive
+planned total, and ``begin_copy_phase`` is called only from the client copy
+flow (via the ``copying`` ``ReportDownloadState``), so the copy commands stay
+silent in every other context: admin, tests, ad-hoc copies.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+log = logging.getLogger(__name__)
+
+_planned: int = 0
+_done: int = 0
+_session_id: str = "unknown"
+_last_emit: float | None = None
+
+# same cadence as the download/verify ticks
+_EMIT_MIN_INTERVAL_SEC = 1.0
+
+
+def begin_copy_phase(planned_bytes, session_id: str = "unknown") -> None:
+    global _planned, _done, _session_id, _last_emit
+    try:
+        _planned = max(0, int(planned_bytes or 0))
+    except (TypeError, ValueError):
+        _planned = 0
+    _done = 0
+    _session_id = session_id or "unknown"
+    _last_emit = None
+
+
+def end_copy_phase() -> None:
+    """Final tick at the full planned total, past the throttle. The phase is over
+    whatever the accounting reached, and without this the bar stops wherever the last
+    throttled tick happened to land."""
+    global _done
+    if _planned <= 0:
+        return
+    _done = _planned
+    report_copy_bytes(0, force=True)
+
+
+def report_copy_bytes(num_bytes, force: bool = False) -> None:
+    """ throttled to one emit per _EMIT_MIN_INTERVAL_SEC, force bypasses the
+        throttle - for the final tick of a phase
+    """
+    global _done, _last_emit
+    if _planned <= 0:
+        return
+    try:
+        _done += max(0, int(num_bytes or 0))
+    except (TypeError, ValueError):
+        return
+    try:
+        now = time.monotonic()
+        if not force and _last_emit is not None and (now - _last_emit) < _EMIT_MIN_INTERVAL_SEC:
+            return
+        _last_emit = now
+        # Lazy import to avoid a pybatch -> pyinstl import cycle at load time.
+        from pyinstl.downloadEvents import emit_session_state
+        emit_session_state(
+            session_id=_session_id,
+            state="copying",
+            phase_bytes_done=min(_done, _planned),
+            phase_bytes_planned=_planned,
+            reason="copy_progress",
+        )
+    except Exception as ex:  # pragma: no cover - instrumentation must never break a copy
+        log.debug(f"could not emit copy progress tick: {ex}")

--- a/pybatch/info_mapBatchCommands.py
+++ b/pybatch/info_mapBatchCommands.py
@@ -15,6 +15,9 @@ import datetime
 log = logging.getLogger(__name__)
 
 from configVar import config_vars
+from configVar import config_var_str
+
+from pyinstl import downloadEvents
 
 import aYaml
 import utils
@@ -138,6 +141,45 @@ class CheckDownloadFolderChecksum(DBManager, PythonBatchCommandBase):
     def is_checksum_ok(self) -> bool:
         retVal = self.num_bad_files == 0
         return retVal
+
+
+class ReportDownloadState(PythonBatchCommandBase, essential=False, call__call__=True, is_context_manager=False, kwargs_defaults={'own_progress_count': 0, 'report_own_progress': False}):
+    """Emit a post-download ``session_state`` transition (Verifying / Installing). Only
+    moves the state machine: ``own_progress_count=0`` / ``report_own_progress=False``
+    so it never perturbs the progress total."""
+
+    def __init__(self, state, reason=None, phase_bytes_planned=None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.state = state
+        self.reason = reason
+        # arms the copy-phase byte accumulator; may be assigned after construction, but
+        # must be set before the script is serialized
+        self.phase_bytes_planned = phase_bytes_planned
+
+    def repr_own_args(self, all_args: List[str]) -> None:
+        all_args.append(self.unnamed__init__param(self.state))
+        all_args.append(self.optional_named__init__param("reason", self.reason, None))
+        all_args.append(self.optional_named__init__param("phase_bytes_planned", self.phase_bytes_planned, None))
+
+    def progress_msg_self(self) -> str:
+        return f'''Report download state {self.state}'''
+
+    def __call__(self, *args, **kwargs) -> None:
+        downloadEvents.emit_download_state(self.state, reason=self.reason)
+        if self.state == "copying" and self.phase_bytes_planned is not None:
+            try:
+                from pybatch.copyPhaseProgress import begin_copy_phase
+                begin_copy_phase(self.phase_bytes_planned,
+                                 config_var_str("__INVOCATION_RANDOM_ID__", "unknown"))
+            except Exception as ex:  # pragma: no cover - instrumentation must never break copy
+                log.debug(f"could not begin copy phase: {ex}")
+        elif self.state == "completed":
+            try:
+                from pybatch.copyPhaseProgress import end_copy_phase
+                end_copy_phase()
+            except Exception as ex:  # pragma: no cover - instrumentation must never break copy
+                log.debug(f"could not end copy phase: {ex}")
+
 
 
 class SetExecPermissionsInSyncFolder(DBManager, PythonBatchCommandBase):

--- a/pybatch/reportingBatchCommands.py
+++ b/pybatch/reportingBatchCommands.py
@@ -333,6 +333,19 @@ class PythonBatchRuntime(pybatch.PythonBatchCommandBase, call__call__=False, is_
             error_dict = self.error_dict(exc_type, exc_val, exc_tb)
         error_json = json.dumps(error_dict, separators=(',', ':'), indent=4, sort_keys=True, default=utils.extra_json_serializer)
         log.error(f"---\n{error_json}\n...\n")
+        self.emit_failed_session_state(exc_type)
+
+    @staticmethod
+    def emit_failed_session_state(exc_type):
+        """Move the structured state machine to its failure terminal. Without it a failed
+        install leaves the last phase reported as still running, which a consumer cannot
+        tell apart from a hang. Lazy import: pybatch is imported while pyinstl is still
+        initializing."""
+        try:
+            from pyinstl.downloadEvents import emit_download_state
+            emit_download_state("failed", reason=exc_type.__name__ if exc_type else "unknown_error")
+        except Exception as ex:  # pragma: no cover - instrumentation must never break the error path
+            log.debug(f"could not emit failed session state: {ex}")
 
     def repr_own_args(self, all_args: List[str]) -> None:
         all_args.append(self.unnamed__init__param(self.name))

--- a/pybatch/test/test_parallelUnwtar.py
+++ b/pybatch/test/test_parallelUnwtar.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3.12
+
+""" Tests for parallel UNWTAR (pybatch.wtarBatchCommands.Unwtar).
+
+    These tests are hermetic: they build real wtar archives on disk with the
+    Wtar command (so the archives carry valid pax_headers/total_checksum), then
+    run Unwtar with DOWNLOAD_PARALLEL_UNWTAR on and off and assert the extracted
+    output is identical, that a single archive still works (serial fallback),
+    and that an extraction error propagates.
+
+    All new tests for this feature live here; the shared test_wtarBatchCommands
+    file is intentionally left untouched.
+"""
+
+import filecmp
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+from pybatch import *
+from pybatch.wtarBatchCommands import Unwtar, _unwtar_one_archive
+
+current_os_names = utils.get_current_os_names()
+config_vars["__CURRENT_OS_NAMES__"] = current_os_names
+
+
+def _is_identical_tree(a: Path, b: Path) -> bool:
+    cmp = filecmp.dircmp(os.fspath(a), os.fspath(b), ignore=['.DS_Store'])
+    if cmp.left_only or cmp.right_only or cmp.diff_files or cmp.funny_files:
+        return False
+    for sub in cmp.subdirs.values():
+        if sub.left_only or sub.right_only or sub.diff_files or sub.funny_files:
+            return False
+    return True
+
+
+class TestParallelUnwtar(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="parallel_unwtar_"))
+        # ensure a clean, predictable flag state for each test
+        config_vars["DOWNLOAD_PARALLEL_UNWTAR"] = "yes"
+        config_vars["DOWNLOAD_PARALLEL_WORKERS"] = "0"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ---- helpers -------------------------------------------------------
+
+    def _make_source_tree(self, root: Path, num_archives: int) -> Path:
+        """ Build <root>/src with num_archives independent sibling subfolders,
+            each holding a few files, then wtar each subfolder in place so the
+            tree contains num_archives independent .wtar.aa first-parts whose
+            destinations do not overlap.  Returns the src path. """
+        src = root.joinpath("src")
+        for i in range(num_archives):
+            sub = src.joinpath(f"item_{i}")
+            sub.mkdir(parents=True, exist_ok=True)
+            for j in range(3):
+                with open(sub.joinpath(f"file_{j}.txt"), "w") as wfd:
+                    wfd.write(f"content of archive {i} file {j}\n" * (10 + i + j))
+            with Wtar(sub, report_own_progress=False) as w:
+                w()
+            # remove the original folder so only the .wtar.aa remains to unwtar
+            shutil.rmtree(sub)
+        return src
+
+    def _run_unwtar(self, src: Path, dest: Path, parallel: bool, no_artifacts=False, copy_owner=True):
+        config_vars["DOWNLOAD_PARALLEL_UNWTAR"] = "yes" if parallel else "no"
+        with Unwtar(src, dest, no_artifacts=no_artifacts, copy_owner=copy_owner, report_own_progress=False) as u:
+            u()
+
+    # ---- tests ---------------------------------------------------------
+
+    def test_repr_roundtrip(self):
+        """ dual-identity: eval(repr(obj)) == obj for Unwtar (unchanged args). """
+        for obj in (Unwtar("/a/b/c"),
+                    Unwtar("/a/b/c", None),
+                    Unwtar("/a/b/c", "/dest", no_artifacts=True)):
+            the_repr = repr(obj)
+            evaled = eval(the_repr)
+            self.assertEqual(obj, evaled, f"repr round-trip failed for {the_repr}")
+
+    def test_parallel_matches_serial_multi_archive(self):
+        """ Same input, flag on vs flag off, must produce identical output. """
+        root = self.tmp.joinpath("multi")
+        src = self._make_source_tree(root, num_archives=4)
+
+        dest_serial = root.joinpath("out_serial")
+        dest_parallel = root.joinpath("out_parallel")
+
+        # Unwtar mutates what_to_unwtar in place; use a fresh command per run and
+        # a fresh copy of the source so no_artifacts/state cannot leak between runs.
+        src_serial = root.joinpath("src_serial")
+        src_parallel = root.joinpath("src_parallel")
+        shutil.copytree(src, src_serial)
+        shutil.copytree(src, src_parallel)
+
+        self._run_unwtar(src_serial, dest_serial, parallel=False)
+        self._run_unwtar(src_parallel, dest_parallel, parallel=True)
+
+        # Unwtar(dir) extracts into dest/<src_basename>/...
+        out_serial = dest_serial.joinpath(src_serial.name)
+        out_parallel = dest_parallel.joinpath(src_parallel.name)
+        self.assertTrue(out_serial.is_dir(), f"serial output missing: {out_serial}")
+        self.assertTrue(out_parallel.is_dir(), f"parallel output missing: {out_parallel}")
+        self.assertTrue(_is_identical_tree(out_serial, out_parallel),
+                        "parallel and serial extracted trees differ")
+        # every archive's content extracted
+        for i in range(4):
+            self.assertTrue(out_parallel.joinpath(f"item_{i}", "file_0.txt").is_file(),
+                            f"missing extracted file for archive {i}")
+
+    def test_single_archive_serial_fallback(self):
+        """ A single archive must take the serial fallback and still extract. """
+        root = self.tmp.joinpath("single")
+        src = self._make_source_tree(root, num_archives=1)
+        dest = root.joinpath("out")
+        # flag on, but only one archive -> serial fallback path
+        self._run_unwtar(src, dest, parallel=True)
+        out = dest.joinpath(src.name)
+        self.assertTrue(out.joinpath("item_0", "file_0.txt").is_file(),
+                        "single-archive (serial fallback) did not extract")
+
+    def test_no_artifacts_removed_parallel(self):
+        """ no_artifacts must remove the wtar files even on the parallel path. """
+        root = self.tmp.joinpath("noartifacts")
+        src = self._make_source_tree(root, num_archives=3)
+        dest = root.joinpath("out")
+        self._run_unwtar(src, dest, parallel=True, no_artifacts=True)
+        leftover = list(src.rglob("*.wtar*"))
+        self.assertEqual(leftover, [], f"no_artifacts left wtar files behind: {leftover}")
+        out = dest.joinpath(src.name)
+        for i in range(3):
+            self.assertTrue(out.joinpath(f"item_{i}", "file_0.txt").is_file(),
+                            f"missing extracted file for archive {i}")
+
+    def test_extraction_error_propagates(self):
+        """ A corrupt archive must make the command raise (failed extract fails
+            the command), on the parallel path. """
+        root = self.tmp.joinpath("err")
+        src = self._make_source_tree(root, num_archives=3)
+        # corrupt one of the first-parts so tarfile cannot read it
+        first_parts = sorted(src.rglob("*.wtar.aa"))
+        self.assertTrue(first_parts, "test setup produced no wtar first-parts")
+        with open(first_parts[0], "wb") as wfd:
+            wfd.write(b"this is not a valid bzip2 tar stream" * 50)
+        dest = root.joinpath("out")
+        with self.assertRaises(Exception):
+            self._run_unwtar(src, dest, parallel=True)
+
+    def test_worker_function_is_picklable_plain_data(self):
+        """ The worker entry point accepts only plain picklable data and runs
+            correctly when called directly (as a process pool would). """
+        root = self.tmp.joinpath("worker")
+        src = self._make_source_tree(root, num_archives=1)
+        first_part = sorted(src.rglob("*.wtar.aa"))[0]
+        dest = root.joinpath("dest")
+        dest.mkdir(parents=True, exist_ok=True)
+        done = _unwtar_one_archive(os.fspath(first_part), os.fspath(dest),
+                                   False, (), False)
+        self.assertTrue(all(isinstance(p, str) for p in done),
+                        "worker must return plain string paths")
+        self.assertTrue(dest.joinpath("item_0", "file_0.txt").is_file(),
+                        "worker did not extract content")
+
+    def test_partition_independent_isolates_overlap(self):
+        """ Overlapping/nested destinations must NOT be partitioned as parallel;
+            clearly-independent destinations must be. """
+        a = self.tmp.joinpath("dst_a")
+        nested = a.joinpath("inner")
+        b = self.tmp.joinpath("dst_b")
+        jobs = [
+            (self.tmp.joinpath("x.wtar.aa"), a),
+            (self.tmp.joinpath("y.wtar.aa"), nested),   # nested under a -> not parallel
+            (self.tmp.joinpath("z.wtar.aa"), b),        # independent
+        ]
+        parallel_jobs, serial_jobs = Unwtar._partition_independent(jobs)
+        parallel_dests = {os.fspath(d) for _, d in parallel_jobs}
+        serial_dests = {os.fspath(d) for _, d in serial_jobs}
+        self.assertIn(os.fspath(b), parallel_dests)
+        self.assertIn(os.fspath(a), serial_dests)
+        self.assertIn(os.fspath(nested), serial_dests)
+
+    def test_partition_independent_matches_comparing_every_pair(self):
+        """ The partition compares sorted neighbours rather than every pair. Pin it
+            against the all-pairs definition it replaced, over shapes that mix
+            siblings, duplicates, deep nesting and unrelated roots. """
+        def overlaps(a: Path, b: Path) -> bool:
+            if a == b:
+                return True
+            for first, second in ((a, b), (b, a)):
+                try:
+                    first.relative_to(second)
+                    return True
+                except ValueError:
+                    pass
+            return False
+
+        def all_pairs_partition(jobs):
+            resolved = [Path(destination) for _, destination in jobs]
+            parallel, serial = [], []
+            for i, job in enumerate(jobs):
+                collides = any(overlaps(resolved[i], resolved[j])
+                               for j in range(len(jobs)) if j != i)
+                (serial if collides else parallel).append(job)
+            return parallel, serial
+
+        root = self.tmp.joinpath("cmp")
+        shapes = [
+            ["a", "b", "c"],                                  # all independent
+            ["a", "a/inner", "b"],                            # one nesting
+            ["a", "a", "b"],                                  # duplicates
+            ["a/b/c", "a", "z", "a/b", "y/x"],                # deep chain, out of order
+            ["p/q", "p/qq", "p/q/r"],                         # prefix that is NOT an ancestor
+            ["solo"],
+            [],
+        ]
+        for shape in shapes:
+            jobs = [(root.joinpath(f"{i}.wtar.aa"), root.joinpath(name))
+                    for i, name in enumerate(shape)]
+            expected_parallel, expected_serial = all_pairs_partition(jobs)
+            actual_parallel, actual_serial = Unwtar._partition_independent(jobs)
+            self.assertEqual(expected_parallel, actual_parallel, f"parallel differs for {shape}")
+            self.assertEqual(expected_serial, actual_serial, f"serial differs for {shape}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pybatch/test/test_reportDownloadState.py
+++ b/pybatch/test/test_reportDownloadState.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3.12
+
+""" Tests for the ReportDownloadState pybatch command and the copy-phase byte
+    funnel it arms.
+
+    ReportDownloadState is a pybatch command, so the first thing that has to hold
+    is the dual-identity contract: its __repr__ must eval back to an equal object.
+    A mismatch there silently corrupts the generated batch script rather than
+    failing loudly.
+
+    The rest is instrumentation, which must move the state machine and report
+    bytes without ever being able to break a copy.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pybatch import *
+from pybatch import ReportDownloadState, CopyFileToFile
+import pybatch.copyPhaseProgress as cpp
+import pyinstl.downloadEvents as downloadEvents
+
+current_os_names = utils.get_current_os_names()
+config_vars["__CURRENT_OS_NAMES__"] = current_os_names
+
+
+class TestReportDownloadStateRepr(unittest.TestCase):
+    def test_repr_round_trips(self):
+        obj = ReportDownloadState("verifying_downloads", reason="checksum_verify",
+                                  own_progress_count=0, report_own_progress=False)
+        obj_recreated = eval(repr(obj))
+        self.assertEqual(obj, obj_recreated, obj.explain_diff(obj_recreated))
+
+    def test_repr_round_trips_with_phase_bytes(self):
+        obj = ReportDownloadState("copying", reason="copy_started", phase_bytes_planned=5000,
+                                  own_progress_count=0, report_own_progress=False)
+        obj_recreated = eval(repr(obj))
+        self.assertEqual(obj, obj_recreated, obj.explain_diff(obj_recreated))
+
+
+class TestReportDownloadStateEmits(unittest.TestCase):
+    def test_emits_the_requested_transition(self):
+        with mock.patch.object(downloadEvents, "emit_session_state") as emit:
+            ReportDownloadState("copying", reason="copy_started",
+                                own_progress_count=0, report_own_progress=False)()
+        emit.assert_called_once()
+        self.assertEqual(emit.call_args.kwargs["state"], "copying")
+        self.assertEqual(emit.call_args.kwargs["reason"], "copy_started")
+
+    def test_never_raises(self):
+        # instrumentation must not be able to break a sync or copy run
+        with mock.patch.object(downloadEvents, "emit_session_state",
+                               side_effect=RuntimeError("emit failed")):
+            ReportDownloadState("completed", own_progress_count=0,
+                                report_own_progress=False)()  # must not raise
+
+    def test_copying_arms_the_copy_phase(self):
+        with mock.patch.object(downloadEvents, "emit_session_state"), \
+                mock.patch.object(cpp, "begin_copy_phase") as begin:
+            ReportDownloadState("copying", reason="copy_started", phase_bytes_planned=5000,
+                                own_progress_count=0, report_own_progress=False)()
+        begin.assert_called_once()
+        self.assertEqual(begin.call_args.args[0], 5000)
+
+
+class TestCopyPhaseByteFunnel(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.addCleanup(cpp.begin_copy_phase, 0)  # disarm whatever a test armed
+
+    def test_copy_file_to_file_reports_bytes_when_armed(self):
+        src = Path(self.temp_dir.name, "src.bin")
+        dst = Path(self.temp_dir.name, "dst.bin")
+        src.write_bytes(b"x" * 1234)
+        cpp.begin_copy_phase(10000, session_id="s")
+        with mock.patch.object(downloadEvents, "emit_session_state") as emit:
+            CopyFileToFile(src, dst, report_own_progress=False)()
+        self.assertTrue(dst.exists())
+        copy_calls = [c.kwargs for c in emit.call_args_list if c.kwargs.get("state") == "copying"]
+        self.assertTrue(copy_calls, "expected a copying tick from the copy funnel")
+        self.assertEqual(copy_calls[-1]["phase_bytes_done"], 1234)
+
+    def test_no_ticks_when_the_phase_was_never_armed(self):
+        src = Path(self.temp_dir.name, "src2.bin")
+        dst = Path(self.temp_dir.name, "dst2.bin")
+        src.write_bytes(b"y" * 10)
+        cpp.begin_copy_phase(0)
+        with mock.patch.object(downloadEvents, "emit_session_state") as emit:
+            CopyFileToFile(src, dst, report_own_progress=False)()
+        self.assertTrue(dst.exists())
+        self.assertEqual([c for c in emit.call_args_list
+                          if c.kwargs.get("state") == "copying"], [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/pybatch/wtarBatchCommands.py
+++ b/pybatch/wtarBatchCommands.py
@@ -4,6 +4,7 @@ import os
 import stat
 import tarfile
 import zipfile
+import concurrent.futures
 from collections import OrderedDict
 from pathlib import Path
 from typing import List
@@ -17,6 +18,71 @@ from .fileSystemBatchCommands import SplitFile, FixAllPermissions, MakeDir
 from .removeBatchCommands import RmDir, RmFile
 
 log = logging.getLogger(__name__)
+
+
+def _unwtar_one_archive(wtar_file_path_str, destination_folder_str, no_artifacts, ignore, copy_owner):
+    """ Extract a single (possibly split) wtar archive. This is a module-level,
+        picklable function so it can run inside a ProcessPoolExecutor worker.
+
+        It receives ONLY plain picklable data (strings/tuples/bools) - never the
+        Unwtar command object nor config_vars. It performs the same extraction,
+        copy_owner (Chown) and no_artifacts removal as the serial path, but it
+        does NOT touch any process-global state (config_vars, the pybatch
+        progress/stage stack, copyPhaseProgress). Progress reporting
+        (report_copy_bytes) is intentionally left to the MAIN process which sums
+        the returned wtar-file sizes after each archive completes.
+
+        Returns the list of wtar file path strings that make up this archive so
+        the caller (main process) can stat/sum their sizes for progress and so
+        error reporting can list them.
+    """
+    wtar_file_path = Path(wtar_file_path_str)
+    destination_folder = Path(destination_folder_str)
+    if ignore is None:
+        ignore = ()
+
+    wtar_file_paths = utils.find_split_files(wtar_file_path)
+
+    log.debug(f"unwtar {wtar_file_path} to {destination_folder}")
+
+    destination_leaf_name = utils.original_name_from_wtar_name(wtar_file_paths[0].name)
+    destination_path = destination_folder.joinpath(destination_leaf_name)
+
+    do_the_unwtarring = True
+    with utils.MultiFileReader("br", wtar_file_paths) as fd:
+        with tarfile.open(fileobj=fd) as tar:
+            tar_total_checksum = tar.pax_headers.get("total_checksum")
+            if tar_total_checksum:
+                try:
+                    if destination_path.exists():
+                        with utils.ChangeDirIfExists(destination_folder):
+                            disk_total_checksum = utils.get_recursive_checksums(destination_leaf_name, ignore=ignore).get("total_checksum", "disk_total_checksum_was_not_found")
+
+                        if disk_total_checksum == tar_total_checksum:
+                            log.debug(f"{wtar_file_paths[0]} skipping unwtarring because item(s) exist and are identical to archive")
+                            do_the_unwtarring = False
+                except:
+                    # if checking checksum failed for any reason -> do the unwtarring
+                    pass
+            if do_the_unwtarring:
+                with RmDir(destination_path, report_own_progress=False, recursive=True) as dir_remover:
+                    # RmDir will also remove a file and will not raise if destination_path does not exist
+                    dir_remover()
+                tar.extractall(destination_folder)
+
+                if copy_owner:
+                    from pybatch import Chown
+                    first_wtar_file_st = wtar_file_paths[0].stat()
+                    Chown(destination_folder, first_wtar_file_st[stat.ST_UID], first_wtar_file_st[stat.ST_GID], recursive=True)()
+            else:
+                log.info(f"skip uwtar of {destination_path} because it exists and matches wtar file checksum")
+
+    if no_artifacts:
+        for wtar_file in wtar_file_paths:
+            with RmFile(wtar_file, report_own_progress=False) as wtar_remover:
+                wtar_remover()
+
+    return [os.fspath(p) for p in wtar_file_paths]
 
 
 def can_skip_unwtar(what_to_work_on: Path, where_to_unwtar: Path):
@@ -192,49 +258,38 @@ class Unwtar(PythonBatchCommandBase):
         # replace plain paths with detailed info such as size, permissions, mod date, user, group
         self.wtar_file_paths = [utils.single_disk_item_listing(wtar_file_path, "PuUgGRTfC") for wtar_file_path in self.wtar_file_paths]
 
+    def _report_archive_bytes(self, wtar_file_path_strs) -> None:
+        """ Report an archive's bytes toward the
+            copy-phase progress (no-op unless an install copy phase is armed).
+            MUST run on the MAIN process - copyPhaseProgress is process-global,
+            non-reentrant state. Best-effort; never breaks a sync. The size is
+            summed from the wtar files; if no_artifacts already removed them the
+            stat will fail and we simply skip (best-effort). """
+        try:
+            from pybatch.copyPhaseProgress import report_copy_bytes
+            total = 0
+            for p in wtar_file_path_strs:
+                try:
+                    total += Path(p).stat().st_size
+                except OSError:
+                    pass
+            report_copy_bytes(total)
+        except Exception:
+            pass
+
     def unwtar_a_file(self, wtar_file_path: Path, destination_folder: Path, no_artifacts=False, ignore=None, copy_owner=False):
         if ignore is None:
             ignore = ()
+        self.wtar_file_paths = utils.find_split_files(wtar_file_path)
+        destination_leaf_name = utils.original_name_from_wtar_name(self.wtar_file_paths[0].name)
+        destination_path = destination_folder.joinpath(destination_leaf_name)
+        self.doing = f"""unwtar file '{wtar_file_path}' to '{destination_folder} ({"already exists" if destination_path.exists() else "not exists"})'"""
         try:
-            self.wtar_file_paths = utils.find_split_files(wtar_file_path)
-
-            log.debug(f"unwtar {wtar_file_path} to {destination_folder}")
-
-            destination_leaf_name = utils.original_name_from_wtar_name(self.wtar_file_paths[0].name)
-            destination_path = destination_folder.joinpath(destination_leaf_name)
-            self.doing = f"""unwtar file '{wtar_file_path}' to '{destination_folder} ({"already exists" if destination_path.exists() else "not exists"})'"""
-
-            do_the_unwtarring = True
-            with utils.MultiFileReader("br", self.wtar_file_paths) as fd:
-                with tarfile.open(fileobj=fd) as tar:
-                    tar_total_checksum = tar.pax_headers.get("total_checksum")
-                    # log.debug(f"total checksum for tarfile(s) {self.wtar_file_paths} {tar_total_checksum}")
-                    if tar_total_checksum:
-                        try:
-                            if destination_path.exists():
-                                with utils.ChangeDirIfExists(destination_folder):
-                                    disk_total_checksum = utils.get_recursive_checksums(destination_leaf_name, ignore=ignore).get("total_checksum", "disk_total_checksum_was_not_found")
-                                    # log.debug(f"total checksum for destination {destination_folder} {disk_total_checksum}")
-
-                                if disk_total_checksum == tar_total_checksum:
-                                    log.debug(f"{self.wtar_file_paths[0]} skipping unwtarring because item(s) exist and are identical to archive")
-                                    do_the_unwtarring = False
-                        except:
-                            # if checking checksum failed for any reason -> do the unwtarring
-                            pass
-                    if do_the_unwtarring:
-                        with RmDir(destination_path, report_own_progress=False, recursive=True) as dir_remover:
-                            # RmDir will also remove a file and will not raise if destination_path does not exist
-                            dir_remover()
-                        tar.extractall(destination_folder)
-
-                        if copy_owner:
-                            from pybatch import Chown
-                            first_wtar_file_st = self.wtar_file_paths[0].stat()
-                            # log.debug(f"copy_owner: {destination_folder} {first_wtar_file_st[stat.ST_UID]}:{first_wtar_file_st[stat.ST_GID]}")
-                            Chown(destination_folder, first_wtar_file_st[stat.ST_UID], first_wtar_file_st[stat.ST_GID], recursive=True)()
-                    else:
-                        log.info(f"skip uwtar of {destination_path} because it exists and matches wtar file checksum")
+            # report bytes BEFORE no_artifacts removal so the wtar files can still
+            # be stat'd; done here (main process) for both serial and parallel paths.
+            done_paths = _unwtar_one_archive(os.fspath(wtar_file_path), os.fspath(destination_folder),
+                                             no_artifacts=False, ignore=ignore, copy_owner=copy_owner)
+            self._report_archive_bytes(done_paths)
             if no_artifacts:
                 for wtar_file in self.wtar_file_paths:
                     with RmFile(wtar_file, report_own_progress=False) as wtar_remover:
@@ -247,6 +302,108 @@ class Unwtar(PythonBatchCommandBase):
         except tarfile.TarError:
             log.warning(f"tarfile error while unwtarring file {self.wtar_file_paths[0]}")
             raise
+
+    @staticmethod
+    def _resolve_worker_count() -> int:
+        """ Number of worker processes for parallel unwtar. DOWNLOAD_PARALLEL_WORKERS=0
+            means auto (os.cpu_count()). Returns >=1; 1 means "run serial". """
+        try:
+            configured = int(config_vars.get("DOWNLOAD_PARALLEL_WORKERS", 0))
+        except (ValueError, TypeError):
+            configured = 0
+        if configured <= 0:
+            configured = os.cpu_count() or 1
+        return max(1, configured)
+
+    @staticmethod
+    def _partition_independent(jobs):
+        """ jobs is a list of (wtar_file_path, destination_folder). Partition into
+            two groups: those whose destination_folder is clearly independent of
+            every other job's destination (no equal/nested/overlapping destination
+            subtree) - safe to run concurrently - and the rest, which must run
+            serially. When in doubt a job is treated as NOT independent.
+
+            Sorting by path components puts every descendant of a folder directly
+            after it, so comparing neighbours finds the same overlaps an all-pairs
+            comparison would, without being quadratic in the job count. """
+        # resolve destination folders once for comparison
+        resolved = []
+        for wtar_file_path, destination_folder in jobs:
+            try:
+                resolved.append(Path(destination_folder).resolve())
+            except OSError:
+                resolved.append(Path(destination_folder))
+
+        parts = [path.parts for path in resolved]
+        order = sorted(range(len(jobs)), key=lambda job_index: parts[job_index])
+        collides = [False] * len(jobs)
+        for earlier, later in zip(order, order[1:]):
+            # equal, or the earlier is an ancestor of the later
+            if parts[later][:len(parts[earlier])] == parts[earlier]:
+                collides[earlier] = collides[later] = True
+
+        parallel_jobs = [job for job_index, job in enumerate(jobs) if not collides[job_index]]
+        serial_jobs = [job for job_index, job in enumerate(jobs) if collides[job_index]]
+        return parallel_jobs, serial_jobs
+
+    def _unwtar_jobs_parallel(self, jobs, ignore_files):
+        """ Run a list of (wtar_file_path, destination_folder) extraction jobs.
+            Honors DOWNLOAD_PARALLEL_UNWTAR / DOWNLOAD_PARALLEL_WORKERS, falls
+            back to serial when the flag is off, workers<=1, or <2 independent
+            jobs. All progress emission and shared-state mutation
+            (self.wtar_file_paths, report_copy_bytes, no_artifacts removal) happen
+            on the MAIN process; workers only extract+chown and return paths. """
+        parallel_enabled = bool(config_vars.get("DOWNLOAD_PARALLEL_UNWTAR", "no"))
+        workers = self._resolve_worker_count()
+
+        parallel_jobs, serial_jobs = ([], jobs)
+        if parallel_enabled and workers > 1 and len(jobs) > 1:
+            parallel_jobs, serial_jobs = self._partition_independent(jobs)
+
+        if len(parallel_jobs) < 2:
+            # not worth a pool / nothing independent -> everything serial
+            serial_jobs = jobs
+            parallel_jobs = []
+
+        if parallel_jobs:
+            workers = min(workers, len(parallel_jobs))
+            futures = {}
+            try:
+                # ThreadPoolExecutor (not ProcessPoolExecutor): instl ships as a
+                # FROZEN PyInstaller binary, where a process pool uses 'spawn' on
+                # macOS/Windows -- it would re-exec the instl binary AND the
+                # workers would not inherit the parent's populated config_vars /
+                # DB state, breaking extraction. Threads run in-process (config_vars
+                # available, no pickling, no freeze_support needed) and still
+                # parallelize: tarfile's bz2 decompression and the file I/O release
+                # the GIL, so independent archives extract concurrently. Worker
+                # archives target disjoint destinations (see _partition_independent),
+                # so concurrent extraction is safe.
+                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+                    for wtar_file_path, destination_folder in parallel_jobs:
+                        fut = executor.submit(_unwtar_one_archive,
+                                              os.fspath(wtar_file_path), os.fspath(destination_folder),
+                                              False, tuple(ignore_files), self.copy_owner)
+                        futures[fut] = (wtar_file_path, destination_folder)
+                    for fut in concurrent.futures.as_completed(futures):
+                        wtar_file_path, destination_folder = futures[fut]
+                        # re-raise worker errors so a failed extract fails the command
+                        done_paths = fut.result()
+                        # main-thread-only shared-state mutation + progress
+                        self.wtar_file_paths = utils.find_split_files(wtar_file_path)
+                        self._report_archive_bytes(done_paths)
+                        if self.no_artifacts:
+                            for wtar_file in done_paths:
+                                with RmFile(wtar_file, report_own_progress=False) as wtar_remover:
+                                    wtar_remover()
+            except Exception as pool_ex:
+                # pool unavailable -> fall back to serial for everything not yet done
+                log.warning(f"parallel unwtar thread pool unavailable, falling back to serial: {pool_ex}")
+                serial_jobs = jobs
+                parallel_jobs = []
+
+        for wtar_file_path, destination_folder in serial_jobs:
+            self.unwtar_a_file(wtar_file_path, destination_folder, no_artifacts=self.no_artifacts, ignore=ignore_files, copy_owner=self.copy_owner)
 
     def __call__(self, *args, **kwargs) -> None:
 
@@ -271,6 +428,10 @@ class Unwtar(PythonBatchCommandBase):
                 destination_folder = self.what_to_unwtar
             self.doing = f"""unwtar folder '{self.what_to_unwtar}' to '{destination_folder}''"""
             if not can_skip_unwtar(self.what_to_unwtar, destination_folder):
+                # collect all independent archive-extraction jobs first, then
+                # dispatch them (parallel when enabled, else serial). Each job is
+                # (first_wtar_file_path, destination_folder_for_that_archive).
+                jobs = []
                 for root, dirs, files in os.walk(self.what_to_unwtar, followlinks=False):
                     # a hack to prevent unwtarring of the sync folder. Copy command might copy something
                     # to the top level of the sync folder.
@@ -285,7 +446,8 @@ class Unwtar(PythonBatchCommandBase):
                         a_file_path = root_Path.joinpath(a_file)
                         if utils.is_first_wtar_file(a_file_path):
                             where_to_unwtar_the_file = destination_folder.joinpath(tail_folder)
-                            self.unwtar_a_file(a_file_path, where_to_unwtar_the_file, no_artifacts=self.no_artifacts, ignore=ignore_files, copy_owner=self.copy_owner)
+                            jobs.append((a_file_path, where_to_unwtar_the_file))
+                self._unwtar_jobs_parallel(jobs, ignore_files)
             else:
                 log.debug(f"unwtar {self.what_to_unwtar} to {self.where_to_unwtar} skipping unwtarring because both folders have the same Info.xml file")
 
@@ -390,7 +552,8 @@ class Unwzip(PythonBatchCommandBase):
             if not target_unwzip_file:  # os.path.split might return empty string
                 target_unwzip_file = Path.cwd()
         if not target_unwzip_file.is_file():
-            # assuming it's a folder
+            # assuming it's a folder to unzip into - make the folder itself
+            # (not just its parent) so the joined target file can be written
             with MakeDir(target_unwzip_file, report_own_progress=False) as md:
                 md()
             if resolved_what_to_unwzip.name.endswith(".wzip"):

--- a/pyinstl/downloadEvents.py
+++ b/pyinstl/downloadEvents.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3.12
+
+"""Structured event contract from instl to Central.
+
+Single source of truth for the JSON-line event channel that Central consumes
+instead of parsing free-text progress. It does not replace the legacy
+progress text; it runs alongside it so older Central builds and the new
+structured consumer both keep working during rollout.
+
+Transport
+---------
+
+Every event is emitted as one log line of the form::
+
+    DOWNLOAD_EVENT {compact-json-with-sorted-keys}
+
+The literal prefix :data:`DOWNLOAD_EVENT_LOG_PREFIX` lets Central identify
+structured events without parsing every output line. The line is written via
+Python ``logging`` at INFO so the existing instl log handlers (which Central
+captures from stdout) carry it without any additional plumbing.
+
+``downloadRetry.format_retry_decision_log_line`` emits the same payload under
+the legacy ``DOWNLOAD_RETRY_DECISION`` prefix, which stays as-is for backward
+compatibility; ``format_retry_decision_event`` wraps that payload in the
+``DOWNLOAD_EVENT`` envelope so consumers can ingest either channel.
+
+Privacy
+-------
+
+* Every helper drops a fixed denylist of keys before serializing.
+* Callers must pass redacted URLs only (use
+  :func:`downloadState.redact_url_for_state` upstream).
+* Hosts may be passed verbatim; the rest of a URL must not flow
+  through this module.
+* Local user paths (``finalPath``, ``tempPath``) are denylisted: they
+  may appear in local diagnostic state but not in structured events.
+
+Event types
+-----------
+
+``download.session_state``
+    Session lifecycle transitions. Fields: ``state`` (one of
+    :class:`DownloadSessionState`), ``previousState`` (optional),
+    ``filesPlanned``, ``bytesPlanned``, ``concurrencyPlanned``,
+    ``actionId``, ``repositoryMajorVersion``, ``repositoryRevision``,
+    ``reason`` (optional, short literal string).
+
+    In-flight ``downloading`` ticks additionally carry ``bytesReceived`` and
+    ``filesCompleted`` (cumulative, monotonic) plus
+    ``observedThroughputBytesPerSecond`` (EMA-smoothed), so Central can
+    compute an ETA without waiting for the end-of-session summary, which
+    only arrives once the download is already over. Lifecycle transitions
+    omit them. Post-download phases (e.g. ``verifying_downloads``) may
+    instead carry ``phaseBytesDone`` / ``phaseBytesPlanned`` to drive a
+    determinate bar through the install tail. All of these are additive and
+    optional, so ``schemaVersion`` is unchanged.
+
+``download.file_state``
+    Per-file transitions. Fields: ``fileId``, ``repoPath``, ``state``
+    (one of :class:`DownloadFileState`), ``previousState`` (optional),
+    ``expectedSize``, ``receivedBytes``, ``retryCount``,
+    ``lastFailureClass`` (optional, :class:`DownloadFailureClass`
+    value), ``resumed`` (bool), ``host`` (optional, bare host).
+
+``download.retry_decision``
+    Wrapped form of the legacy
+    ``downloadRetry.format_retry_decision_log_line`` payload. Fields:
+    ``failureClass``, ``attempt``, ``decision``, ``delayMs``,
+    ``restartRequired``, ``reason``, ``receivedBytes``, ``concurrency``,
+    ``retryAfterSeconds``, ``httpStatus``, ``curlExitCode``, ``repoPath``,
+    ``fileId``.
+
+``download.capability``
+    One-shot snapshot of the backend feature flags Central uses for UX
+    gating. Fields: ``resumeEnabled``, ``validatedHosts`` (list, bare hosts
+    only), ``retryMatrixVersion`` (int), ``stateSchemaVersion`` (int),
+    ``eventSchemaVersion`` (int), ``featureFlags`` (map), ``centralUxEnabled``,
+    ``telemetryEnabled``, ``retryPolicyEnabled``.
+
+``download.session_summary``
+    The aggregated session totals ``downloadObservability`` writes as
+    ``session-summary.json``, so Central need not read the sidecar to
+    render end-of-session UI.
+
+Envelope
+--------
+
+All events share the same envelope::
+
+    {
+        "event":             <event-type>,
+        "schemaVersion":     <int>,
+        "sessionId":         <opaque-id>,
+        "timestamp":         <ISO-8601 UTC, seconds resolution>,
+        ...event-specific fields...
+    }
+
+``timestamp`` is computed at line-format time (not on the caller's
+behalf) so retries through the formatter remain deterministic when
+the caller supplies an explicit value.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+from configVar import config_vars, config_var_str
+
+DOWNLOAD_EVENT_LOG_PREFIX = "DOWNLOAD_EVENT"
+DOWNLOAD_EVENT_SCHEMA_VERSION = 1
+
+_log = logging.getLogger(__name__)
+
+
+class DownloadEventType(str, Enum):
+    """Canonical event identifiers. Consumers must accept unknown values
+    and treat them as forward-compatible no-ops."""
+
+    SESSION_STATE = "download.session_state"
+    FILE_STATE = "download.file_state"
+    RETRY_DECISION = "download.retry_decision"
+    CAPABILITY = "download.capability"
+    SESSION_SUMMARY = "download.session_summary"
+
+
+# The kill switches reported on the capability event, so a failed install's log
+# says which recovery layers were active. Defaults match defaults/InstlClient.yaml
+# and only apply when the key is undefined (an older client yaml); once loaded,
+# the yaml wins.
+_REPORTED_FLAGS: tuple[tuple[str, bool], ...] = (
+    ("DOWNLOAD_TELEMETRY_ENABLED", True),
+    ("DOWNLOAD_RESUME_ENABLED", True),
+    ("DOWNLOAD_RETRY_POLICY_ENABLED", True),
+    ("DOWNLOAD_CENTRAL_UX_ENABLED", True),
+    ("DOWNLOAD_RECONCILE_MISSING_OUTPUTS", True),
+    ("DOWNLOAD_OFFLINE_HOLD_ENABLED", True),
+    ("DOWNLOAD_CURL_STALL_DETECTION", True),
+    ("DOWNLOAD_REDOWNLOAD_ALL_BAD_FILES", True),
+    # set to true only by a NEW Central, which treats backend-hold evidence as
+    # informational and never auto-pauses on it; default FALSE so an old
+    # Central sees only the legacy event stream while the engine still recovers
+    ("DOWNLOAD_CLIENT_HANDLES_BACKEND_HOLD", False),
+)
+
+
+def active_flags_from_config(config_vars: Any) -> dict[str, bool]:
+    """Read :data:`_REPORTED_FLAGS` for the capability event's ``featureFlags``."""
+    return {name: _read_flag(config_vars, name, default) for name, default in _REPORTED_FLAGS}
+
+
+def _read_flag(config_vars: Any, name: str, default: bool) -> bool:
+    try:
+        if config_vars is None:
+            return default
+        # `config_vars` is the instl ConfigVarStack: `__getitem__` returns a
+        # variable with `.bool()`. Mapping-style access is for tests.
+        if hasattr(config_vars, "__contains__") and name not in config_vars:
+            return default
+        var = config_vars[name]
+        if hasattr(var, "bool"):
+            return bool(var.bool())
+        if isinstance(var, bool):
+            return var
+        if isinstance(var, (int, float)):
+            return bool(var)
+        return str(var).strip().lower() in ("yes", "true", "1", "on")
+    except Exception:
+        return default
+
+
+# Dropped by the formatter rather than emit auth/header/local-path material.
+# Kept compatible with ``downloadRetry._DISALLOWED_EVENT_FIELDS``.
+_DISALLOWED_EVENT_FIELDS = frozenset({
+    "url", "URL", "urlRedacted", "headers", "cookie", "cookies",
+    "authorization", "Authorization", "policy", "signature",
+    "Signed-URL", "signedUrl", "tempPath", "finalPath",
+    "localPath", "downloadPath",
+})
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _drop_disallowed(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not mapping:
+        return {}
+    return {k: v for k, v in mapping.items() if k not in _DISALLOWED_EVENT_FIELDS}
+
+
+def _enum_value(value: Any) -> Any:
+    """Flatten enums for JSON serialization; anything else passes through."""
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def make_envelope(event_type: DownloadEventType | str,
+                  *,
+                  session_id: str | None,
+                  timestamp: str | None = None,
+                  schema_version: int = DOWNLOAD_EVENT_SCHEMA_VERSION) -> dict[str, Any]:
+    """Build the shared envelope used by every event type."""
+    return {
+        "event": _enum_value(event_type) or DownloadEventType.SESSION_STATE.value,
+        "schemaVersion": int(schema_version),
+        "sessionId": session_id or "unknown",
+        "timestamp": timestamp or _utc_now_iso(),
+    }
+
+
+def format_event_line(event: Mapping[str, Any]) -> str:
+    """Return the single-line log record for ``event``.
+
+    :data:`DOWNLOAD_EVENT_LOG_PREFIX`, a space, then compact JSON with sorted
+    keys. Denylisted keys are dropped here too, so a caller that forgets the
+    redaction contract still cannot leak auth material.
+    """
+    safe = _drop_disallowed(event)
+    return f"{DOWNLOAD_EVENT_LOG_PREFIX} {json.dumps(safe, sort_keys=True)}"
+
+
+def emit_event(event: Mapping[str, Any]) -> str | None:
+    """Format and emit ``event`` via the module logger. Returns the line.
+
+    Returns ``None`` and writes nothing when :func:`set_telemetry_enabled`
+    has turned the channel off.
+    """
+    if not _telemetry_enabled:
+        return None
+    try:
+        line = format_event_line(event)
+    except Exception as fmt_ex:  # pragma: no cover - defensive
+        _log.debug(f"could not format download event: {fmt_ex}")
+        return None
+    try:
+        _log.info(line)
+    except Exception as log_ex:  # pragma: no cover - defensive
+        _log.debug(f"could not write download event: {log_ex}")
+    return line
+
+
+# -- Telemetry kill switch --------------------------------------------------
+#
+# Default ON in shipped builds; process-global, so rollout/support can disable
+# the channel out-of-band if a downstream parser regresses.
+
+_telemetry_enabled: bool = True
+
+
+def set_telemetry_enabled(enabled: bool) -> None:
+    """Toggle the structured-event kill switch.
+
+    Called from ``do_check_checksum`` based on ``DOWNLOAD_TELEMETRY_ENABLED``.
+    The legacy ``DOWNLOAD_RETRY_DECISION`` text line comes from
+    ``downloadRetry`` and is NOT affected by this switch.
+    """
+    global _telemetry_enabled
+    _telemetry_enabled = bool(enabled)
+
+
+def is_telemetry_enabled() -> bool:
+    return _telemetry_enabled
+
+
+# -- Builders ---------------------------------------------------------------
+
+
+def make_session_state_event(*,
+                             session_id: str | None,
+                             state: Any,
+                             previous_state: Any = None,
+                             files_planned: int | None = None,
+                             bytes_planned: int | None = None,
+                             concurrency_planned: int | None = None,
+                             action_id: str | None = None,
+                             repository_major_version: int | None = None,
+                             repository_revision: int | None = None,
+                             reason: str | None = None,
+                             bytes_received: int | None = None,
+                             files_completed: int | None = None,
+                             observed_throughput_bytes_per_second: int | None = None,
+                             phase_bytes_done: int | None = None,
+                             phase_bytes_planned: int | None = None,
+                             timestamp: str | None = None) -> dict[str, Any]:
+    payload = make_envelope(DownloadEventType.SESSION_STATE,
+                            session_id=session_id, timestamp=timestamp)
+    payload.update({
+        "state": _enum_value(state),
+        "previousState": _enum_value(previous_state),
+        "filesPlanned": int(files_planned) if files_planned is not None else None,
+        "bytesPlanned": int(bytes_planned) if bytes_planned is not None else None,
+        "concurrencyPlanned": int(concurrency_planned) if concurrency_planned is not None else None,
+        "actionId": action_id,
+        "repositoryMajorVersion": int(repository_major_version) if repository_major_version is not None else None,
+        "repositoryRevision": int(repository_revision) if repository_revision is not None else None,
+        "reason": reason,
+    })
+    # live-progress fields, included only when supplied so lifecycle-transition
+    # events keep their existing shape
+    if bytes_received is not None:
+        payload["bytesReceived"] = int(bytes_received)
+    if files_completed is not None:
+        payload["filesCompleted"] = int(files_completed)
+    if observed_throughput_bytes_per_second is not None:
+        payload["observedThroughputBytesPerSecond"] = int(observed_throughput_bytes_per_second)
+    # per-phase byte progress for post-download phases (e.g. verify); distinct
+    # from the download-phase bytesReceived/bytesPlanned above
+    if phase_bytes_done is not None:
+        payload["phaseBytesDone"] = int(phase_bytes_done)
+    if phase_bytes_planned is not None:
+        payload["phaseBytesPlanned"] = int(phase_bytes_planned)
+    return payload
+
+
+def make_file_state_event(*,
+                          session_id: str | None,
+                          file_id: str | None,
+                          repo_path: str | None,
+                          state: Any,
+                          previous_state: Any = None,
+                          expected_size: int | None = None,
+                          received_bytes: int | None = None,
+                          retry_count: int | None = None,
+                          last_failure_class: Any = None,
+                          resumed: bool | None = None,
+                          host: str | None = None,
+                          timestamp: str | None = None) -> dict[str, Any]:
+    payload = make_envelope(DownloadEventType.FILE_STATE,
+                            session_id=session_id, timestamp=timestamp)
+    payload.update({
+        "fileId": file_id,
+        "repoPath": repo_path,
+        "state": _enum_value(state),
+        "previousState": _enum_value(previous_state),
+        "expectedSize": int(expected_size) if expected_size is not None else None,
+        "receivedBytes": int(received_bytes) if received_bytes is not None else None,
+        "retryCount": int(retry_count) if retry_count is not None else None,
+        "lastFailureClass": _enum_value(last_failure_class),
+        "resumed": bool(resumed) if resumed is not None else None,
+        "host": host,
+    })
+    return payload
+
+
+def make_capability_event(*,
+                          session_id: str | None,
+                          resume_enabled: bool,
+                          validated_hosts: Iterable[str] | None = None,
+                          retry_matrix_version: int = 1,
+                          state_schema_version: int = 1,
+                          feature_flags: Mapping[str, Any] | None = None,
+                          central_ux_enabled: bool | None = None,
+                          telemetry_enabled: bool | None = None,
+                          retry_policy_enabled: bool | None = None,
+                          timestamp: str | None = None) -> dict[str, Any]:
+    payload = make_envelope(DownloadEventType.CAPABILITY,
+                            session_id=session_id, timestamp=timestamp)
+    safe_hosts: list[str] = []
+    if validated_hosts:
+        for raw in validated_hosts:
+            host = str(raw or "").strip().lower()
+            if not host or "/" in host or "?" in host or "#" in host:
+                continue  # only bare host strings
+            safe_hosts.append(host)
+    safe_flags: dict[str, bool] = {}
+    if feature_flags:
+        for key, value in feature_flags.items():
+            if not isinstance(key, str) or not key:
+                continue
+            safe_flags[key] = bool(value)
+    payload.update({
+        "resumeEnabled": bool(resume_enabled),
+        "validatedHosts": sorted(set(safe_hosts)),
+        "retryMatrixVersion": int(retry_matrix_version),
+        "stateSchemaVersion": int(state_schema_version),
+        "eventSchemaVersion": DOWNLOAD_EVENT_SCHEMA_VERSION,
+        "featureFlags": safe_flags,
+        "centralUxEnabled": bool(central_ux_enabled) if central_ux_enabled is not None else False,
+        "telemetryEnabled": bool(telemetry_enabled) if telemetry_enabled is not None else True,
+        "retryPolicyEnabled": bool(retry_policy_enabled) if retry_policy_enabled is not None else True,
+    })
+    return payload
+
+
+def make_session_summary_event(*,
+                               session_id: str | None,
+                               summary: Mapping[str, Any],
+                               timestamp: str | None = None) -> dict[str, Any]:
+    """Wrap the ``session-summary.json`` payload in the event envelope.
+
+    ``downloadObservability`` already produced it redacted (host-only, no
+    URLs/paths).
+    """
+    payload = make_envelope(DownloadEventType.SESSION_SUMMARY,
+                            session_id=session_id, timestamp=timestamp)
+    payload["summary"] = _drop_disallowed(summary)
+    return payload
+
+
+def make_retry_decision_event(decision,
+                              *,
+                              session_id: str | None,
+                              file_id: str | None = None,
+                              repo_path: str | None = None,
+                              received_bytes: int | None = None,
+                              concurrency: int | None = None,
+                              timestamp: str | None = None) -> dict[str, Any]:
+    """Build the unified-envelope form of the retry decision event.
+
+    Field names mirror ``downloadRetry.RetryDecision.to_event`` so Central can
+    use one parser for both the legacy ``DOWNLOAD_RETRY_DECISION`` line and
+    this ``DOWNLOAD_EVENT`` line.
+    """
+    payload = make_envelope(DownloadEventType.RETRY_DECISION,
+                            session_id=session_id, timestamp=timestamp)
+    failure_class = getattr(decision, "failure_class", None)
+    action = getattr(decision, "action", None)
+    payload.update({
+        "fileId": file_id,
+        "repoPath": repo_path,
+        "failureClass": _enum_value(failure_class),
+        "attempt": int(getattr(decision, "attempt", 0) or 0),
+        "decision": _enum_value(action),
+        "delayMs": int(round(float(getattr(decision, "delay_seconds", 0.0) or 0.0) * 1000)),
+        "restartRequired": bool(getattr(decision, "restart_required", False)),
+        "reason": getattr(decision, "reason", ""),
+        "receivedBytes": int(received_bytes) if received_bytes is not None else None,
+        "concurrency": int(concurrency) if concurrency is not None else None,
+        "retryAfterSeconds": getattr(decision, "retry_after_seconds", None),
+        "httpStatus": getattr(decision, "http_status", None),
+        "curlExitCode": getattr(decision, "curl_exit_code", None),
+    })
+    return payload
+
+
+# -- Convenience emitters ---------------------------------------------------
+
+
+def emit_session_state(**kwargs) -> str | None:
+    return emit_event(make_session_state_event(**kwargs))
+
+
+def emit_file_state(**kwargs) -> str | None:
+    return emit_event(make_file_state_event(**kwargs))
+
+
+def emit_capability(**kwargs) -> str | None:
+    return emit_event(make_capability_event(**kwargs))
+
+
+def emit_session_summary(**kwargs) -> str | None:
+    return emit_event(make_session_summary_event(**kwargs))
+
+
+def emit_retry_decision(decision, **kwargs) -> str | None:
+    return emit_event(make_retry_decision_event(decision, **kwargs))
+
+
+# -- config-aware session_state emission --------------------------
+
+
+def download_event_context():
+    """Session id + rollout flags for a download event, applying the telemetry kill
+    switch. Each instl invocation is its own process, so a later `copy` must re-read the
+    flag that the `sync` before it honored."""
+    rollout_flags = active_flags_from_config(config_vars)
+    telemetry_enabled = bool(rollout_flags.get("DOWNLOAD_TELEMETRY_ENABLED", True))
+    set_telemetry_enabled(telemetry_enabled)
+    return config_var_str("__INVOCATION_RANDOM_ID__", "unknown"), rollout_flags, telemetry_enabled
+
+
+def emit_download_state(state, reason=None, files_planned=None, bytes_planned=None):
+    """Emit a session_state transition for a phase that is not the transfer itself -
+    preparing before anything runs, verify and copy/unwtar after curl is done, failed on
+    the way out. Lives here rather than next to the phase that calls it: every caller is
+    a different subsystem and none of them should have to import another to say where
+    the install has got to."""
+    try:
+        session_id, _rollout_flags, _telemetry_enabled = download_event_context()
+        emit_session_state(
+            session_id=session_id,
+            state=state,
+            files_planned=files_planned,
+            bytes_planned=bytes_planned,
+            reason=reason,
+        )
+    except Exception as ex:  # pragma: no cover - instrumentation must never break sync
+        _log.debug(f"could not emit download state {state!r}: {ex}")
+
+
+__all__ = [
+    "DOWNLOAD_EVENT_LOG_PREFIX",
+    "DOWNLOAD_EVENT_SCHEMA_VERSION",
+    "DownloadEventType",
+    "active_flags_from_config",
+    "download_event_context",
+    "emit_capability",
+    "emit_download_state",
+    "emit_event",
+    "emit_file_state",
+    "emit_retry_decision",
+    "emit_session_state",
+    "emit_session_summary",
+    "format_event_line",
+    "make_capability_event",
+    "make_envelope",
+    "make_file_state_event",
+    "make_retry_decision_event",
+    "make_session_state_event",
+    "make_session_summary_event",
+]

--- a/pyinstl/downloadFailures.py
+++ b/pyinstl/downloadFailures.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3.12
+
+import errno
+import email.utils
+import os
+import socket
+import ssl
+import subprocess
+import urllib.error
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+try:
+    import requests
+except Exception:  # pragma: no cover - requests is optional for admin-only environments
+    requests = None
+
+
+class DownloadFailureClass(str, Enum):
+    DNS_RESOLUTION = "dns_resolution"
+    TCP_CONNECT = "tcp_connect"
+    TLS = "tls"
+    TIMEOUT_BEFORE_FIRST_BYTE = "timeout_before_first_byte"
+    TIMEOUT_DURING_TRANSFER = "timeout_during_transfer"
+    HTTP_429 = "http_429"
+    HTTP_5XX = "http_5xx"
+    HTTP_AUTH_POLICY = "http_auth_policy"
+    HTTP_4XX = "http_4xx"
+    HTTP_ERROR = "http_error"
+    DISK_WRITE = "disk_write"
+    DISK_SPACE = "disk_space"
+    PERMISSION_DENIED = "permission_denied"
+    CHECKSUM_MISMATCH = "checksum_mismatch"
+    PARTIAL_TRANSFER = "partial_transfer"
+    PROCESS_TERMINATED = "process_terminated"
+    CANCELLED = "cancelled"
+    MISSING_AFTER_TRANSFER = "missing_after_transfer"
+    MALFORMED_URL = "malformed_url"
+    NETWORK_SEND_ERROR = "network_send_error"
+    NETWORK_RECEIVE_ERROR = "network_receive_error"
+    UNKNOWN_DOWNLOAD_ERROR = "unknown_download_error"
+
+
+RETRYABLE_FAILURE_CLASSES = frozenset({
+    DownloadFailureClass.DNS_RESOLUTION,
+    DownloadFailureClass.TCP_CONNECT,
+    DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE,
+    DownloadFailureClass.TIMEOUT_DURING_TRANSFER,
+    DownloadFailureClass.HTTP_429,
+    DownloadFailureClass.HTTP_5XX,
+    DownloadFailureClass.HTTP_ERROR,
+    DownloadFailureClass.CHECKSUM_MISMATCH,
+    DownloadFailureClass.PARTIAL_TRANSFER,
+    DownloadFailureClass.PROCESS_TERMINATED,
+    DownloadFailureClass.MISSING_AFTER_TRANSFER,
+    DownloadFailureClass.NETWORK_SEND_ERROR,
+    DownloadFailureClass.NETWORK_RECEIVE_ERROR,
+})
+
+
+CURL_ERROR_DESCRIPTIONS = {
+    3: "URL malformed",
+    5: "Couldnt resolve proxy",
+    6: "Couldn't resolve host",
+    7: "Failed to connect to host",
+    18: "Partial file. Only a part of the file was transferred",
+    21: "Quote error. A quote command returned an error from the server",
+    22: "HTTP page not retrieved. The requested url was not found or returned another error",
+    23: "Write error. Curl could not write data to a local filesystem",
+    28: "Operation timeout. The specified time-out period was reached according to the conditions",
+    33: "HTTP range request failed. The server did not return a usable partial response",
+    35: "TLS/SSL connect error",
+    51: "The peer's SSL certificate or SSH MD5 fingerprint was not OK",
+    52: "Nothing was returned from the server",
+    55: "Failure while sending network data",
+    56: "Failure while receiving network data",
+    60: "Peer certificate cannot be authenticated with known CA certificates",
+    77: "Problem with the SSL CA cert",
+}
+
+
+@dataclass(frozen=True)
+class DownloadFailureInfo:
+    failure_class: DownloadFailureClass
+    retryable: bool
+    source: str
+    reason: str = ""
+    curl_exit_code: int | None = None
+    http_status: int | None = None
+    retry_after_seconds: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "failureClass": self.failure_class.value,
+            "retryable": self.retryable,
+            "source": self.source,
+            "reason": self.reason,
+            "curlExitCode": self.curl_exit_code,
+            "httpStatus": self.http_status,
+            "retryAfterSeconds": self.retry_after_seconds,
+        }
+
+
+def is_retryable_failure_class(failure_class: DownloadFailureClass | str) -> bool:
+    if not isinstance(failure_class, DownloadFailureClass):
+        try:
+            failure_class = DownloadFailureClass(failure_class)
+        except ValueError:
+            return False
+    return failure_class in RETRYABLE_FAILURE_CLASSES
+
+
+def _failure_info(
+        failure_class: DownloadFailureClass,
+        source: str,
+        reason: str = "",
+        curl_exit_code: int | None = None,
+        http_status: int | None = None,
+        retry_after_seconds: int | None = None) -> DownloadFailureInfo:
+    return DownloadFailureInfo(
+        failure_class=failure_class,
+        retryable=is_retryable_failure_class(failure_class),
+        source=source,
+        reason=reason,
+        curl_exit_code=curl_exit_code,
+        http_status=http_status,
+        retry_after_seconds=retry_after_seconds,
+    )
+
+
+def retry_after_seconds(header_value: Any, now: datetime | None = None) -> int | None:
+    if header_value is None:
+        return None
+    value = str(header_value).strip()
+    if not value:
+        return None
+    try:
+        return max(0, int(value))
+    except ValueError:
+        pass
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return max(0, int((parsed.astimezone(timezone.utc) - now.astimezone(timezone.utc)).total_seconds()))
+
+
+def _header_value(headers: Any, header_name: str) -> Any:
+    if not headers:
+        return None
+    if hasattr(headers, "get"):
+        return headers.get(header_name)
+    return None
+
+
+def classify_http_status(status_code: int | str | None, headers: Any = None) -> DownloadFailureInfo:
+    try:
+        status = int(status_code)
+    except (TypeError, ValueError):
+        return _failure_info(DownloadFailureClass.HTTP_ERROR, "http_status", "missing_or_invalid_http_status")
+
+    retry_after = retry_after_seconds(_header_value(headers, "Retry-After"))
+    if status == 429:
+        return _failure_info(
+            DownloadFailureClass.HTTP_429,
+            "http_status",
+            "too_many_requests",
+            http_status=status,
+            retry_after_seconds=retry_after,
+        )
+    if status == 408:
+        return _failure_info(
+            DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE,
+            "http_status",
+            "request_timeout",
+            http_status=status,
+            retry_after_seconds=retry_after,
+        )
+    if 500 <= status <= 599:
+        return _failure_info(
+            DownloadFailureClass.HTTP_5XX,
+            "http_status",
+            "server_error",
+            http_status=status,
+            retry_after_seconds=retry_after,
+        )
+    if status in (401, 403, 407):
+        return _failure_info(
+            DownloadFailureClass.HTTP_AUTH_POLICY,
+            "http_status",
+            "auth_or_policy_failure",
+            http_status=status,
+            retry_after_seconds=retry_after,
+        )
+    if 400 <= status <= 499:
+        return _failure_info(
+            DownloadFailureClass.HTTP_4XX,
+            "http_status",
+            "client_error",
+            http_status=status,
+            retry_after_seconds=retry_after,
+        )
+    return _failure_info(
+        DownloadFailureClass.HTTP_ERROR,
+        "http_status",
+        "unexpected_http_status",
+        http_status=status,
+        retry_after_seconds=retry_after,
+    )
+
+
+def classify_curl_exit_code(
+        exit_code: int | str | None,
+        http_status: int | str | None = None,
+        headers: Any = None,
+        received_bytes: int | None = None) -> DownloadFailureInfo:
+    try:
+        curl_exit_code = int(exit_code)
+    except (TypeError, ValueError):
+        return _failure_info(DownloadFailureClass.UNKNOWN_DOWNLOAD_ERROR, "curl", "missing_or_invalid_curl_exit_code")
+
+    if curl_exit_code == 22:
+        info = classify_http_status(http_status, headers) if http_status is not None else _failure_info(
+            DownloadFailureClass.HTTP_ERROR,
+            "curl",
+            "http_error_without_status",
+        )
+        return DownloadFailureInfo(
+            failure_class=info.failure_class,
+            retryable=info.retryable,
+            source="curl",
+            reason=info.reason,
+            curl_exit_code=curl_exit_code,
+            http_status=info.http_status,
+            retry_after_seconds=info.retry_after_seconds,
+        )
+    if curl_exit_code in (5, 6):
+        failure_class = DownloadFailureClass.DNS_RESOLUTION
+    elif curl_exit_code == 7:
+        failure_class = DownloadFailureClass.TCP_CONNECT
+    elif curl_exit_code in (35, 51, 60, 77):
+        failure_class = DownloadFailureClass.TLS
+    elif curl_exit_code == 28:
+        failure_class = (
+            DownloadFailureClass.TIMEOUT_DURING_TRANSFER
+            if received_bytes and received_bytes > 0
+            else DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE
+        )
+    elif curl_exit_code in (18, 33):
+        failure_class = DownloadFailureClass.PARTIAL_TRANSFER
+    elif curl_exit_code == 23:
+        failure_class = DownloadFailureClass.DISK_WRITE
+    elif curl_exit_code == 55:
+        failure_class = DownloadFailureClass.NETWORK_SEND_ERROR
+    elif curl_exit_code in (52, 56):
+        failure_class = DownloadFailureClass.NETWORK_RECEIVE_ERROR
+    elif curl_exit_code == 3:
+        failure_class = DownloadFailureClass.MALFORMED_URL
+    else:
+        failure_class = DownloadFailureClass.UNKNOWN_DOWNLOAD_ERROR
+
+    return _failure_info(
+        failure_class,
+        "curl",
+        CURL_ERROR_DESCRIPTIONS.get(curl_exit_code, "unmapped_curl_exit_code"),
+        curl_exit_code=curl_exit_code,
+    )
+
+
+def curl_error_description(exit_code: int | str | None) -> str | None:
+    try:
+        return CURL_ERROR_DESCRIPTIONS.get(int(exit_code))
+    except (TypeError, ValueError):
+        return None
+
+
+def _iter_exception_chain(exc: BaseException):
+    seen = set()
+    current = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _contains_exception(exc: BaseException, exception_type) -> bool:
+    return any(isinstance(chained, exception_type) for chained in _iter_exception_chain(exc))
+
+
+def _message_contains(exc: BaseException, *needles: str) -> bool:
+    message = " ".join(str(chained) for chained in _iter_exception_chain(exc)).lower()
+    return any(needle.lower() in message for needle in needles)
+
+
+def _classify_requests_exception(exc: BaseException) -> DownloadFailureInfo | None:
+    if requests is None or not isinstance(exc, requests.exceptions.RequestException):
+        return None
+    if isinstance(exc, requests.exceptions.HTTPError) and getattr(exc, "response", None) is not None:
+        return classify_http_status(exc.response.status_code, exc.response.headers)
+    if isinstance(exc, requests.exceptions.ConnectTimeout):
+        return _failure_info(DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE, "requests", "connect_timeout")
+    if isinstance(exc, requests.exceptions.ReadTimeout):
+        return _failure_info(DownloadFailureClass.TIMEOUT_DURING_TRANSFER, "requests", "read_timeout")
+    if isinstance(exc, requests.exceptions.SSLError):
+        return _failure_info(DownloadFailureClass.TLS, "requests", "tls_error")
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        if _contains_exception(exc, socket.gaierror) or _message_contains(exc, "name resolution", "getaddrinfo", "resolve"):
+            return _failure_info(DownloadFailureClass.DNS_RESOLUTION, "requests", "dns_resolution")
+        return _failure_info(DownloadFailureClass.TCP_CONNECT, "requests", "connection_error")
+    if isinstance(exc, requests.exceptions.Timeout):
+        return _failure_info(DownloadFailureClass.TIMEOUT_DURING_TRANSFER, "requests", "timeout")
+    if getattr(exc, "response", None) is not None:
+        return classify_http_status(exc.response.status_code, exc.response.headers)
+    return _failure_info(DownloadFailureClass.UNKNOWN_DOWNLOAD_ERROR, "requests", exc.__class__.__name__)
+
+
+def _classify_urllib_exception(exc: BaseException) -> DownloadFailureInfo | None:
+    if isinstance(exc, urllib.error.HTTPError):
+        return classify_http_status(exc.code, exc.headers)
+    if not isinstance(exc, urllib.error.URLError):
+        return None
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, socket.gaierror):
+        return _failure_info(DownloadFailureClass.DNS_RESOLUTION, "urllib", "dns_resolution")
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return _failure_info(DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE, "urllib", "timeout")
+    if isinstance(reason, ssl.SSLError):
+        return _failure_info(DownloadFailureClass.TLS, "urllib", "tls_error")
+    if isinstance(reason, ConnectionRefusedError):
+        return _failure_info(DownloadFailureClass.TCP_CONNECT, "urllib", "connection_refused")
+    if _message_contains(exc, "getaddrinfo", "nodename nor servname", "name or service not known"):
+        return _failure_info(DownloadFailureClass.DNS_RESOLUTION, "urllib", "dns_resolution")
+    if _message_contains(exc, "timed out"):
+        return _failure_info(DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE, "urllib", "timeout")
+    if _message_contains(exc, "ssl", "certificate", "tls"):
+        return _failure_info(DownloadFailureClass.TLS, "urllib", "tls_error")
+    return _failure_info(DownloadFailureClass.TCP_CONNECT, "urllib", "url_error")
+
+
+def _classify_os_error(exc: BaseException) -> DownloadFailureInfo | None:
+    if not isinstance(exc, OSError):
+        return None
+    if exc.errno == errno.ENOSPC:
+        return _failure_info(DownloadFailureClass.DISK_SPACE, "os", "no_space_left")
+    if exc.errno in (errno.EACCES, errno.EPERM):
+        return _failure_info(DownloadFailureClass.PERMISSION_DENIED, "os", "permission_denied")
+    if exc.errno in (errno.EIO, errno.EBADF):
+        return _failure_info(DownloadFailureClass.DISK_WRITE, "os", "disk_write")
+    return None
+
+
+def classify_exception(exc: BaseException) -> DownloadFailureInfo:
+    requests_info = _classify_requests_exception(exc)
+    if requests_info:
+        return requests_info
+    urllib_info = _classify_urllib_exception(exc)
+    if urllib_info:
+        return urllib_info
+    os_error_info = _classify_os_error(exc)
+    if os_error_info:
+        return os_error_info
+    if isinstance(exc, subprocess.CalledProcessError):
+        return _failure_info(DownloadFailureClass.PROCESS_TERMINATED, "process", "called_process_error")
+    if exc.__class__.__name__ == "ProcessTerminatedExternally":
+        return _failure_info(DownloadFailureClass.PROCESS_TERMINATED, "process", "terminated_externally")
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+        return _failure_info(DownloadFailureClass.CANCELLED, "process", "cancelled")
+
+    message = str(exc).lower()
+    if "bad checksum" in message:
+        return _failure_info(DownloadFailureClass.CHECKSUM_MISMATCH, "exception_text", "bad_checksum")
+    if "no space left" in message or "enospc" in message:
+        return _failure_info(DownloadFailureClass.DISK_SPACE, "exception_text", "no_space_left")
+    if "permission denied" in message or "operation not permitted" in message or "access is denied" in message:
+        return _failure_info(DownloadFailureClass.PERMISSION_DENIED, "exception_text", "permission_denied")
+    if "missing" in message or "was not found" in message:
+        return _failure_info(DownloadFailureClass.MISSING_AFTER_TRANSFER, "exception_text", "missing_after_transfer")
+
+    return _failure_info(DownloadFailureClass.UNKNOWN_DOWNLOAD_ERROR, "exception", exc.__class__.__name__)

--- a/pyinstl/downloadObservability.py
+++ b/pyinstl/downloadObservability.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3.12
+
+"""Throughput and error sampling for the bulk download engine.
+
+Aggregation runs in-process during a single ``instl`` invocation; callers feed
+it normalized outcomes from the existing ``CheckDownloadFolderChecksum`` and
+``downloadVerify.emit_retry_decision`` choke points. The summary is persisted as a small
+JSON sidecar next to ``session.json`` under
+``$(LOCAL_REPO_BOOKKEEPING_DIR)/download-state`` — client-owned local state,
+and emitted as the ``download.session_summary`` event Central renders from.
+
+Hosts are stored as bare hostnames (no path, query, or fragment); no URLs,
+cookies, headers, signed-URL material, or local user paths flow through this
+module. ``record_*`` never raises — instrumentation must not break a sync run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+try:
+    from .downloadFailures import DownloadFailureClass
+except ImportError:  # tests import via sys.path without the pyinstl package context
+    from downloadFailures import DownloadFailureClass  # type: ignore[no-redef]
+
+
+DOWNLOAD_OBSERVABILITY_SCHEMA_VERSION = 1
+SESSION_SUMMARY_FILE_NAME = "session-summary.json"
+STATE_DIR_NAME = "download-state"
+
+
+# -- Outcome enum -----------------------------------------------------------
+
+
+class DownloadOutcome(str):
+    """Outcome of a single per-file attempt.
+
+    A string subclass rather than an Enum so JSON serialization is trivial and
+    callers can compare against literals without importing the type.
+    """
+
+    SUCCESS = "success"
+    FAILED_RETRYABLE = "failed_retryable"
+    FAILED_TERMINAL = "failed_terminal"
+    RESTART_FORCED = "restart_forced"
+
+
+_VALID_OUTCOMES = frozenset({
+    DownloadOutcome.SUCCESS,
+    DownloadOutcome.FAILED_RETRYABLE,
+    DownloadOutcome.FAILED_TERMINAL,
+    DownloadOutcome.RESTART_FORCED,
+})
+
+
+# -- Host classification ----------------------------------------------------
+
+
+def host_from_url(in_url: str | None) -> str | None:
+    """Return the lowercase host of ``in_url`` or ``None``.
+
+    Strips userinfo, port, query, fragment. Hosts are safe to log and are
+    needed to bucket throughput/error signal per CDN host.
+    """
+    if not in_url:
+        return None
+    try:
+        parsed = urlsplit(in_url)
+    except ValueError:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None  # relative path or malformed input; do not invent a host
+    return host.lower()
+
+
+# -- Counters ---------------------------------------------------------------
+
+
+@dataclass
+class _HostCounters:
+    attempts: int = 0
+    successes: int = 0
+    failures_retryable: int = 0
+    failures_terminal: int = 0
+    restarts: int = 0
+    bytes_received: int = 0
+    transfer_time_seconds: float = 0.0
+    failure_classes: dict[str, int] = field(default_factory=dict)
+
+    def record(self, outcome: str, *,
+               failure_class: str | None,
+               bytes_received: int,
+               transfer_time_seconds: float) -> None:
+        self.attempts += 1
+        if bytes_received > 0:
+            self.bytes_received += int(bytes_received)
+        if transfer_time_seconds and transfer_time_seconds > 0:
+            self.transfer_time_seconds += float(transfer_time_seconds)
+        if outcome == DownloadOutcome.SUCCESS:
+            self.successes += 1
+        elif outcome == DownloadOutcome.FAILED_RETRYABLE:
+            self.failures_retryable += 1
+        elif outcome == DownloadOutcome.FAILED_TERMINAL:
+            self.failures_terminal += 1
+        elif outcome == DownloadOutcome.RESTART_FORCED:
+            self.restarts += 1
+        if failure_class:
+            self.failure_classes[failure_class] = self.failure_classes.get(failure_class, 0) + 1
+
+    def to_dict(self) -> dict[str, Any]:
+        # milliseconds, so JSON diffs stay readable across timer precisions
+        transfer_ms = int(round(self.transfer_time_seconds * 1000))
+        return {
+            "attempts": self.attempts,
+            "successes": self.successes,
+            "failuresRetryable": self.failures_retryable,
+            "failuresTerminal": self.failures_terminal,
+            "restarts": self.restarts,
+            "bytesReceived": self.bytes_received,
+            "transferMs": transfer_ms,
+            "failureClasses": dict(self.failure_classes),
+        }
+
+
+# -- Observability session --------------------------------------------------
+
+
+class DownloadObservability:
+    """Per-session in-memory aggregator.
+
+    Callers must not pass headers, cookies, signed-URL query strings, or local
+    user paths; of the URL, only the host is retained.
+    """
+
+    def __init__(self, session_id: str | None = None,
+                 concurrency_planned: int | None = None,
+                 started_at: str | None = None,
+                 wall_clock: "_WallClock | None" = None) -> None:
+        self.session_id = session_id or "unknown"
+        self.concurrency_planned = concurrency_planned
+        self.started_at = started_at or _utc_now_iso()
+        self._wall_clock = wall_clock or _WallClock()
+        self._wall_start = self._wall_clock.monotonic()
+        self._totals = _HostCounters()
+        self._per_host: dict[str, _HostCounters] = {}
+        self._files_planned: int = 0
+        self._bytes_planned: int = 0
+        self._finished_at: str | None = None
+        self._wall_seconds: float | None = None
+
+    # --- planning hooks ----------------------------------------------------
+
+    def set_plan(self, files_planned: int | None, bytes_planned: int | None) -> None:
+        try:
+            if files_planned is not None:
+                self._files_planned = max(0, int(files_planned))
+            if bytes_planned is not None:
+                self._bytes_planned = max(0, int(bytes_planned))
+        except (TypeError, ValueError):
+            return
+
+    # --- recording hooks ---------------------------------------------------
+
+    def record_outcome(self,
+                       *,
+                       outcome: str,
+                       url: str | None = None,
+                       host: str | None = None,
+                       failure_class: DownloadFailureClass | str | None = None,
+                       bytes_received: int | None = None,
+                       transfer_time_seconds: float | None = None) -> None:
+        """Record one per-file attempt outcome.
+
+        ``url`` is consumed only to derive the host; nothing else is stored.
+        """
+        try:
+            if outcome not in _VALID_OUTCOMES:
+                return
+            host_key = host or host_from_url(url) or "unknown"
+            failure_value = _failure_class_value(failure_class)
+            byte_count = int(bytes_received) if bytes_received is not None and bytes_received > 0 else 0
+            transfer_seconds = float(transfer_time_seconds) if transfer_time_seconds and transfer_time_seconds > 0 else 0.0
+            self._totals.record(
+                outcome,
+                failure_class=failure_value,
+                bytes_received=byte_count,
+                transfer_time_seconds=transfer_seconds,
+            )
+            host_counters = self._per_host.setdefault(host_key, _HostCounters())
+            host_counters.record(
+                outcome,
+                failure_class=failure_value,
+                bytes_received=byte_count,
+                transfer_time_seconds=transfer_seconds,
+            )
+        except Exception:  # pragma: no cover - instrumentation must never raise
+            return
+
+    def record_retry_decision(self,
+                              decision,
+                              *,
+                              url: str | None = None,
+                              host: str | None = None,
+                              bytes_received: int | None = None) -> None:
+        """Map a ``RetryDecision`` to an outcome and record it.
+
+        Successful transfers flow through
+        ``record_outcome(outcome=SUCCESS, ...)`` separately.
+        """
+        try:
+            action = getattr(decision, "action", None)
+            failure_class = getattr(decision, "failure_class", None)
+            action_value = getattr(action, "value", action)
+            if action_value == "fail_terminal":
+                outcome = DownloadOutcome.FAILED_TERMINAL
+            elif action_value == "restart":
+                outcome = DownloadOutcome.RESTART_FORCED
+            else:
+                outcome = DownloadOutcome.FAILED_RETRYABLE
+            self.record_outcome(
+                outcome=outcome,
+                url=url,
+                host=host,
+                failure_class=failure_class,
+                bytes_received=bytes_received,
+            )
+        except Exception:  # pragma: no cover
+            return
+
+    # --- snapshot/persist --------------------------------------------------
+
+    def mark_finished(self) -> None:
+        if self._finished_at is None:
+            self._finished_at = _utc_now_iso()
+            self._wall_seconds = max(0.0, self._wall_clock.monotonic() - self._wall_start)
+
+    def snapshot(self) -> dict[str, Any]:
+        wall_seconds = self._wall_seconds
+        if wall_seconds is None:
+            wall_seconds = max(0.0, self._wall_clock.monotonic() - self._wall_start)
+        total_bytes = self._totals.bytes_received
+        observed_throughput_bps = 0
+        if wall_seconds > 0 and total_bytes > 0:
+            observed_throughput_bps = int(total_bytes / wall_seconds)
+        error_rate = 0.0
+        if self._totals.attempts > 0:
+            non_success = self._totals.attempts - self._totals.successes
+            error_rate = round(non_success / self._totals.attempts, 4)
+        retryable_rate = 0.0
+        if self._totals.attempts > 0:
+            retryable_rate = round(self._totals.failures_retryable / self._totals.attempts, 4)
+        return {
+            "schemaVersion": DOWNLOAD_OBSERVABILITY_SCHEMA_VERSION,
+            "sessionId": self.session_id,
+            "startedAt": self.started_at,
+            "finishedAt": self._finished_at,
+            "wallMs": int(round(wall_seconds * 1000)),
+            "concurrencyPlanned": self.concurrency_planned,
+            "filesPlanned": self._files_planned,
+            "bytesPlanned": self._bytes_planned,
+            "totals": self._totals.to_dict(),
+            "observedThroughputBytesPerSecond": observed_throughput_bps,
+            "errorRate": error_rate,
+            "retryableErrorRate": retryable_rate,
+            "hosts": {
+                host: counters.to_dict()
+                for host, counters in sorted(self._per_host.items())
+            },
+        }
+
+    def save(self, bookkeeping_dir: str | Path | None) -> Path | None:
+        """Persist the snapshot to ``download-state/session-summary.json``.
+
+        Returns the output path, or ``None`` on any failure (including a
+        missing or non-writable bookkeeping dir).
+        """
+        if not bookkeeping_dir:
+            return None
+        try:
+            self.mark_finished()
+            state_dir = Path(bookkeeping_dir).joinpath(STATE_DIR_NAME)
+            state_dir.mkdir(parents=True, exist_ok=True)
+            target = state_dir.joinpath(SESSION_SUMMARY_FILE_NAME)
+            _atomic_write_json(target, self.snapshot())
+            return target
+        except Exception:  # pragma: no cover - persistence is best-effort
+            return None
+
+
+# -- Module-level singleton -------------------------------------------------
+
+
+_active_observability: DownloadObservability | None = None
+
+
+def start_session(session_id: str | None = None,
+                  concurrency_planned: int | None = None) -> DownloadObservability:
+    """Begin a new session-scoped sampler and install it as the active one.
+
+    The module-level ``record_*`` functions delegate to this instance until the
+    next ``start_session`` call, which drops the previous one without
+    persisting it.
+    """
+    global _active_observability
+    _active_observability = DownloadObservability(
+        session_id=session_id,
+        concurrency_planned=concurrency_planned,
+    )
+    return _active_observability
+
+
+def active() -> DownloadObservability | None:
+    return _active_observability
+
+
+def end_session(bookkeeping_dir: str | Path | None = None) -> Path | None:
+    """Finalize and persist the active sampler. Returns the file path."""
+    global _active_observability
+    if _active_observability is None:
+        return None
+    target = _active_observability.save(bookkeeping_dir)
+    _active_observability = None
+    return target
+
+
+def record_outcome(**kwargs) -> None:
+    """Module-level convenience: record on the active session if any."""
+    if _active_observability is None:
+        return
+    _active_observability.record_outcome(**kwargs)
+
+
+def record_retry_decision(decision, **kwargs) -> None:
+    if _active_observability is None:
+        return
+    _active_observability.record_retry_decision(decision, **kwargs)
+
+
+def set_plan(files_planned: int | None, bytes_planned: int | None) -> None:
+    if _active_observability is None:
+        return
+    _active_observability.set_plan(files_planned, bytes_planned)
+
+
+# -- Internal helpers -------------------------------------------------------
+
+
+class _WallClock:
+    """Indirection so tests can inject a deterministic clock."""
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _failure_class_value(failure_class: DownloadFailureClass | str | None) -> str | None:
+    if failure_class is None:
+        return None
+    if isinstance(failure_class, DownloadFailureClass):
+        return failure_class.value
+    try:
+        return DownloadFailureClass(failure_class).value
+    except (TypeError, ValueError):
+        return None
+
+
+def _atomic_write_json(target: Path, payload: Mapping[str, Any]) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".session-summary-", suffix=".json", dir=os.fspath(target.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as wfd:
+            json.dump(payload, wfd, sort_keys=True)
+            wfd.flush()
+            os.fsync(wfd.fileno())
+        os.replace(tmp_name, target)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+__all__ = [
+    "DOWNLOAD_OBSERVABILITY_SCHEMA_VERSION",
+    "DownloadObservability",
+    "DownloadOutcome",
+    "active",
+    "end_session",
+    "host_from_url",
+    "record_outcome",
+    "record_retry_decision",
+    "set_plan",
+    "start_session",
+]

--- a/pyinstl/instlClient.py
+++ b/pyinstl/instlClient.py
@@ -13,6 +13,7 @@ from .instlInstanceBase import InstlInstanceBase, check_version_compatibility
 from configVar import config_vars
 from pybatch import *
 from .connectionBase import connection_factory
+from . import downloadEvents
 
 
 class InstlClient(InstlInstanceBase):
@@ -63,7 +64,17 @@ class InstlClient(InstlInstanceBase):
             sync_folder = os.path.join("$(LOCAL_REPO_SYNC_DIR)", relative_sync_folder)
             self.__no_copy_iids_by_sync_folder[sync_folder].append(IID)
 
+    # the commands that drive a session Central follows; uninstall/remove/read_yaml/
+    # report_versions have no download or copy phase to report
+    session_commands = ('sync', 'copy', 'synccopy')
+
     def do_command(self):
+        if self.fixed_command in InstlClient.session_commands:
+            # everything up to the first batch command - yaml read, inheritance, item
+            # calculation, the sync-folder scan - emitted no structured signal at all,
+            # and it is where a multi-minute stall was once recorded with nothing to
+            # attribute it to
+            downloadEvents.emit_download_state("preparing", reason="instl_started")
         active_oses: List[str] = list(config_vars["TARGET_OS_NAMES"])
         # utils.add_to_actions_stack(f"""updating DB: active oses'""")
         self.items_table.activate_specific_oses(*active_oses)

--- a/pyinstl/instlClientCopy.py
+++ b/pyinstl/instlClientCopy.py
@@ -13,6 +13,7 @@ log = logging.getLogger()
 
 from configVar import config_vars
 from .instlClient import InstlClient
+from .instlException import InstlFatalException
 import svnTree
 from pybatch import *
 
@@ -37,9 +38,12 @@ class InstlClientCopy(InstlClient):
                                                 'post_copy': "post-install step",
                                                 'pre_copy_to_folder': "pre-copy step",
                                                 'post_copy_to_folder': "post-copy step"})
+        # source bytes the copy phase will process. The same unit the copy commands
+        # report back: RsyncClone.copy_file_to_file reports a copied file's size and
+        # Unwtar._report_archive_bytes reports an archive's COMPRESSED size, so scaling
+        # wtar items by an expansion ratio here would leave an all-wtar install topping
+        # out at 1/ratio of its own bar
         self.bytes_to_copy = 0
-        # ratio between wtar file and it's uncompressed contents
-        self.wtar_ratio = float(config_vars.get("WTAR_RATIO", "1.3"))
 
         # when running on MacOS AND installation targets MacOS some special cases need to be considered
         self.mac_current_and_target = 'Mac' in list(config_vars["__CURRENT_OS_NAMES__"]) and 'Mac' in list(config_vars["TARGET_OS"])
@@ -72,6 +76,18 @@ class InstlClientCopy(InstlClient):
         # Copy might be called after the sync batch file was created, but before it was executed
         if len(self.info_map_table.files_read_list) == 0:
             have_info_path = os.fspath(config_vars["HAVE_INFO_MAP_COPY_PATH"])
+            # Only pre-check local paths (a URL is read directly by the reader).
+            # The info-map describes the synced files; without it copy cannot
+            # proceed, and the previous behavior surfaced an opaque
+            # FileNotFoundError from deep inside the reader. Point the user at the
+            # likely cause (sync not run / wrong path) instead.
+            is_url = "://" in have_info_path
+            if not is_url and not os.path.isfile(have_info_path):
+                raise InstlFatalException(
+                    f"Cannot copy: the synced files manifest was not found at '{have_info_path}'",
+                    "(config var HAVE_INFO_MAP_COPY_PATH).",
+                    "This usually means the 'sync' step did not run or did not complete.",
+                    "Run sync before copy, or check the HAVE_INFO_MAP_COPY_PATH setting.")
             self.info_map_table.read_from_file(have_info_path, disable_indexes_during_read=True)
 
         self.avoid_copy_markers = list(config_vars.get('AVOID_COPY_MARKERS', []))
@@ -80,6 +96,17 @@ class InstlClientCopy(InstlClient):
         self.batch_accum.set_current_section('copy')
         self.batch_accum += self.create_sync_folder_manifest_command("before-copy", back_ground=True)
         self.batch_accum += Progress("Start copy from $(COPY_SOURCES_ROOT_DIR)")
+        # Announce the copy/install phase so
+        # Central's structured UX shows "Installing" instead of a bar frozen
+        # near 99% while files are copied and archives unwtarred (often the
+        # slowest, least-visible part of an install). copy may run in its own
+        # instl invocation (after sync), so this is emitted here, not in sync.
+        # Keep a reference so phase_bytes_planned can be filled in after the copy
+        # loop below accumulates bytes_to_copy (the command is positioned before
+        # the copies but serialized afterward, so the emitted script carries the
+        # final planned total).
+        copying_state_command = ReportDownloadState("copying", reason="copy_started",
+                                                    own_progress_count=0, report_own_progress=False)
 
         sorted_target_folder_list = sorted(self.all_iids_by_target_folder,
                                            key=lambda fold: config_vars.resolve_str(fold))
@@ -91,6 +118,13 @@ class InstlClientCopy(InstlClient):
 
         if self.mac_current_and_target:
             self.pre_copy_mac_handling()
+
+        # appended only here: folder creation and the pre_copy actions above contribute
+        # no bytes, so announcing copying before them left the phase bar at 0 through
+        # thousands of MakeDirs. The per-target-folder removal of a previous install is
+        # interleaved with the copies below and cannot be lifted out of the phase without
+        # restructuring the loop, so it stays inside it
+        self.batch_accum += copying_state_command
 
         remove_previous_sources = bool(config_vars.get("REMOVE_PREVIOUS_SOURCES",True))
         for target_folder_path in sorted_target_folder_list:
@@ -105,6 +139,12 @@ class InstlClientCopy(InstlClient):
                 folder_accum += self.create_copy_instructions_for_no_copy_folder(sync_folder_name)
 
         self.progress(self.bytes_to_copy, "bytes to copy")
+        # Now that the copy loop has accumulated the total
+        # install footprint, arm the copy-phase byte progress. Serialization
+        # happens after this returns, so the "copying" command emitted into the
+        # script carries this planned total and the copy/unwtar commands report
+        # determinate progress against it.
+        copying_state_command.phase_bytes_planned = self.bytes_to_copy
 
         self.batch_accum += self.accumulate_unique_actions_for_active_iids('post_copy')
 
@@ -121,23 +161,31 @@ class InstlClientCopy(InstlClient):
         # messages about orphan iids
         for iid in sorted(list(config_vars["__ORPHAN_INSTALL_TARGETS__"])):
             self.batch_accum += Echo(f"Don't know how to install {iid}")
+        # The install is finished -- move Central's
+        # structured UX to its terminal state so the dialog doesn't linger on
+        # "Installing" after the work is actually done.
+        self.batch_accum += ReportDownloadState("completed", reason="install_complete",
+                                                own_progress_count=0, report_own_progress=False)
         self.batch_accum += Progress("Done copy")
         self.progress("create copy instructions done")
         self.progress("")
 
-    def calc_size_of_file_item(self, a_file_item: svnTree.SVNRow) -> int:
-        """ for use with builtin function reduce to calculate the unwtarred size of a file """
-        if a_file_item.is_wtar_file():
-            item_size = int(float(a_file_item.size) * self.wtar_ratio)
-        else:
-            item_size = a_file_item.size
-        return item_size
+    @staticmethod
+    def size_of_source_items(source_items: List[svnTree.SVNRow]) -> int:
+        """ source bytes the copy phase will process, see bytes_to_copy """
+        return sum(item.size for item in source_items)
 
     def create_copy_instructions_for_file(self, source_path: str, name_for_progress_message: str, use_hard_links=True) -> PythonBatchCommandBase:
         retVal = AnonymousAccum()
         source_files = self.info_map_table.get_required_for_file(source_path)
         if not source_files:
-            log.warning(f"""no source files for {source_path}""")
+            # The index references a file that is absent from the info-map (the
+            # synced repo listing). This usually means the source was not synced,
+            # the path in index.yaml is wrong, or the repo-rev is mismatched.
+            # Nothing gets copied for it; make that visible with the owning item.
+            owning_iid = f" (item '{self.current_iid}')" if self.current_iid else ""
+            log.warning(f"no source files found for '{source_path}'{owning_iid}; "
+                        f"it will not be copied. Check that it was synced and that its path in index.yaml is correct.")
             return retVal
         num_wtars: int = functools.reduce(lambda total, item: total + item.wtarFlag, source_files, 0)
         assert (len(source_files) == 1 and num_wtars == 0) or num_wtars == len(source_files)
@@ -152,12 +200,12 @@ class InstlClientCopy(InstlClient):
                 if not source_file.path.endswith(".symlink"):
                     retVal += ChmodAndChown(path=source_file.name(), mode=source_file.chmod_spec(), user_id=int(config_vars.get("ACTING_UID", -1)), group_id=int(config_vars.get("ACTING_GID", -1)), recursive=False)
 
-            self.bytes_to_copy += self.calc_size_of_file_item(source_file)
+            self.bytes_to_copy += source_file.size
         else:  # one or more wtar files
             # do not increment retVal - unwtar_instructions will add its own instructions
             first_wtar_item = None
             for source_wtar in source_files:
-                self.bytes_to_copy += self.calc_size_of_file_item(source_wtar)
+                self.bytes_to_copy += source_wtar.size
                 if source_wtar.is_first_wtar_file():
                     first_wtar_item = source_wtar
             assert first_wtar_item is not None
@@ -173,13 +221,16 @@ class InstlClientCopy(InstlClient):
         no_wtar_items = [source_item for source_item in source_items if not source_item.wtarFlag]
         wtar_items = [source_item for source_item in source_items if source_item.wtarFlag]
 
+        # outside the no_wtar_items branch: a directory holding only wtar items still
+        # emits an Unwtar, which reports its bytes, so accumulating only under the
+        # branch left that work done-without-planned
+        self.bytes_to_copy += self.size_of_source_items(source_items)
+
         if no_wtar_items:
             retVal += CopyDirContentsToDir(source_path_abs,
                                             os.curdir,
                                             hard_links=use_hard_links,
                                             preserve_dest_files=True)  # preserve files already in destination
-
-            self.bytes_to_copy += functools.reduce(lambda total, item: total + self.calc_size_of_file_item(item), source_items, 0)
 
             if self.mac_current_and_target:
                 for source_item in source_items:
@@ -201,7 +252,7 @@ class InstlClientCopy(InstlClient):
             source_items: List[svnTree.SVNRow] = self.info_map_table.get_items_in_dir(dir_path=source_path)
             has_wtars = any(source_item.wtarFlag for source_item in source_items)
             source_path_abs = os.path.normpath("$(COPY_SOURCES_ROOT_DIR)/" + source_path)
-            self.bytes_to_copy += functools.reduce(lambda total, item: total + self.calc_size_of_file_item(item), source_items, 0)
+            self.bytes_to_copy += self.size_of_source_items(source_items)
 
             source_path_dir, source_path_name = os.path.split(source_path)
 
@@ -236,7 +287,7 @@ class InstlClientCopy(InstlClient):
                                    os.curdir,
                                    hard_links=use_hard_links,
                                    delete_extraneous_files=True)
-            self.bytes_to_copy += functools.reduce(lambda total, item: total + self.calc_size_of_file_item(item), source_items, 0)
+            self.bytes_to_copy += self.size_of_source_items(source_items)
 
             source_path_dir, source_path_name = os.path.split(source_path)
 
@@ -276,7 +327,14 @@ class InstlClientCopy(InstlClient):
             case '!dir_cont':  # get all files and folders from a folder
                 retVal = self.create_copy_instructions_for_dir_cont(source[0], name_for_progress_message, use_hard_links)
             case _:
-                raise ValueError(f"unknown source type {source[1]} for {source[0]}")
+                # Unknown source tag in index.yaml. Name the offending item so
+                # whoever maintains the index can find and fix it; valid tags are
+                # !dir, !file and !dir_cont. (Kept as ValueError to preserve the
+                # established exception-type contract; only the message is richer.)
+                owning_iid = f" of item '{self.current_iid}'" if self.current_iid else ""
+                raise ValueError(
+                    f"Cannot create copy instructions: unknown source type '{source[1]}' "
+                    f"for source '{source[0]}'{owning_iid} (expected one of !dir, !file, !dir_cont).")
         return retVal
 
     # special handling when running on macOS

--- a/pyinstl/instlInstanceSync_url.py
+++ b/pyinstl/instlInstanceSync_url.py
@@ -149,6 +149,10 @@ class InstlInstanceSync_url(InstlInstanceSync):
         dl_commands += self.create_curl_download_instructions()
 
         dl_commands += self.instlObj.create_sync_folder_manifest_command("after-sync", back_ground=True)
+        # announce the verify phase, otherwise Central's bar sits frozen near 99%
+        # while checksums are recomputed over the downloaded files
+        dl_commands += ReportDownloadState("verifying_downloads", reason="checksum_verify",
+                                           own_progress_count=0, report_own_progress=False)
         dl_commands += self.create_check_checksum_instructions(to_sync_num_files)
         return dl_commands
 
@@ -175,6 +179,10 @@ class InstlInstanceSync_url(InstlInstanceSync):
                         self.instlObj.progress("create download instructions done")
                     post_sync_accum_transaction += CopyFileToFile("$(NEW_HAVE_INFO_MAP_PATH)", "$(HAVE_INFO_MAP_PATH)", hard_links=False, copy_owner=True)
 
+        # a sync-only run ends here: without this it stops on verifying_downloads and
+        # never reaches a terminal state. synccopy passes straight through it to copying
+        sync_accum += ReportDownloadState("ready_to_copy", reason="sync_complete",
+                                          own_progress_count=0, report_own_progress=False)
         sync_accum += Progress("Done sync")
 
     def chown_for_synced_folders(self):

--- a/pyinstl/instlMisc.py
+++ b/pyinstl/instlMisc.py
@@ -86,7 +86,93 @@ class InstlMisc(InstlInstanceBase):
     def do_check_checksum(self):
         self.progress_staccato_command = True
         info_map_file = os.fspath(config_vars["__MAIN_INPUT_FILE__"])
-        CheckDownloadFolderChecksum(info_map_file, print_report=True, raise_on_bad_checksum=True)()
+        # scope the throughput/error sampler to this in-process check-checksum
+        # invocation: CheckDownloadFolderChecksum and its re_download_bad_files
+        # retry loop both record outcomes against the active session
+        from . import downloadObservability  # local import to keep startup cheap
+        from . import downloadEvents
+        try:
+            session_id = str(config_vars.get("__INVOCATION_RANDOM_ID__", "unknown"))
+        except Exception:
+            session_id = "unknown"
+        try:
+            concurrency_planned = int(config_vars.get("PARALLEL_SYNC", 0))
+        except Exception:
+            concurrency_planned = None
+        downloadObservability.start_session(
+            session_id=session_id,
+            concurrency_planned=concurrency_planned,
+        )
+        # announce the backend capability snapshot so Central can gate
+        # pause/resume/retry-failed UI without parsing text. Errors here must
+        # not break the sync run.
+        try:
+            resume_enabled = bool(config_vars.get("DOWNLOAD_RESUME_ENABLED", False))
+        except Exception:
+            resume_enabled = False
+        # resume is a download-engine capability; nothing here can validate a host
+        # for it, so the snapshot reports none
+        validated_hosts = []
+        # read the kill-switch map once and apply the process-level switches
+        # before any emitter fires for this session. ``DOWNLOAD_TELEMETRY_ENABLED=no``
+        # disables the structured event channel; the legacy text log is unaffected.
+        rollout_flags = downloadEvents.active_flags_from_config(config_vars)
+        telemetry_enabled = bool(rollout_flags.get("DOWNLOAD_TELEMETRY_ENABLED", True))
+        retry_policy_enabled = bool(rollout_flags.get("DOWNLOAD_RETRY_POLICY_ENABLED", True))
+        central_ux_enabled = bool(rollout_flags.get("DOWNLOAD_CENTRAL_UX_ENABLED", False))
+        downloadEvents.set_telemetry_enabled(telemetry_enabled)
+        try:
+            downloadEvents.emit_capability(
+                session_id=session_id,
+                resume_enabled=resume_enabled,
+                validated_hosts=validated_hosts,
+                feature_flags=rollout_flags,
+                central_ux_enabled=central_ux_enabled,
+                telemetry_enabled=telemetry_enabled,
+                retry_policy_enabled=retry_policy_enabled,
+            )
+            downloadEvents.emit_session_state(
+                session_id=session_id,
+                state="verifying_existing_files",
+                concurrency_planned=concurrency_planned,
+                reason="check_checksum_started",
+            )
+        except Exception:
+            pass
+        try:
+            CheckDownloadFolderChecksum(info_map_file, print_report=True, raise_on_bad_checksum=True)()
+        finally:
+            try:
+                bookkeeping_dir = config_vars["LOCAL_REPO_BOOKKEEPING_DIR"].str() if "LOCAL_REPO_BOOKKEEPING_DIR" in config_vars else None
+            except Exception:
+                bookkeeping_dir = None
+            summary_snapshot = None
+            try:
+                active = downloadObservability.active()
+                if active is not None:
+                    active.mark_finished()
+                    summary_snapshot = active.snapshot()
+            except Exception:
+                summary_snapshot = None
+            downloadObservability.end_session(bookkeeping_dir)
+            try:
+                # ready_to_copy, not completed: check-checksum verifies an already
+                # downloaded tree, so its own end is not the end of an install. A
+                # terminal completed here would move a caller's state machine past
+                # every phase that still has to run
+                downloadEvents.emit_session_state(
+                    session_id=session_id,
+                    state="ready_to_copy",
+                    concurrency_planned=concurrency_planned,
+                    reason="check_checksum_finished",
+                )
+                if summary_snapshot is not None:
+                    downloadEvents.emit_session_summary(
+                        session_id=session_id,
+                        summary=summary_snapshot,
+                    )
+            except Exception:
+                pass
 
     def do_test_import(self):
         import importlib

--- a/pyinstl/test/test_downloadEvents.py
+++ b/pyinstl/test/test_downloadEvents.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3.12
+
+"""Tests for the structured DOWNLOAD_EVENT channel.
+
+These tests exercise ``downloadEvents`` without any ``instl`` runtime
+dependency. They cover the JSON-line envelope, redaction denylist,
+event type builders, host validation in ``make_capability_event``, and
+the unified retry decision event shape.
+"""
+
+import json
+import logging
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir)))
+
+from downloadEvents import (
+    DOWNLOAD_EVENT_LOG_PREFIX,
+    DOWNLOAD_EVENT_SCHEMA_VERSION,
+    DownloadEventType,
+    active_flags_from_config,
+    emit_event,
+    format_event_line,
+    make_capability_event,
+    make_envelope,
+    make_file_state_event,
+    make_retry_decision_event,
+    make_session_state_event,
+    make_session_summary_event,
+)
+from downloadFailures import DownloadFailureClass
+
+
+def _parse_line(line):
+    self_test = line.split(" ", 1)
+    assert self_test[0] == DOWNLOAD_EVENT_LOG_PREFIX, line
+    return json.loads(self_test[1])
+
+
+class TestEnvelope(unittest.TestCase):
+    def test_envelope_has_required_fields(self):
+        env = make_envelope(DownloadEventType.SESSION_STATE,
+                            session_id="abc",
+                            timestamp="2026-05-17T10:00:00Z")
+        self.assertEqual(env["event"], "download.session_state")
+        self.assertEqual(env["schemaVersion"], DOWNLOAD_EVENT_SCHEMA_VERSION)
+        self.assertEqual(env["sessionId"], "abc")
+        self.assertEqual(env["timestamp"], "2026-05-17T10:00:00Z")
+
+    def test_envelope_defaults_session_id_when_missing(self):
+        env = make_envelope(DownloadEventType.CAPABILITY,
+                            session_id=None, timestamp="2026-05-17T10:00:00Z")
+        self.assertEqual(env["sessionId"], "unknown")
+
+    def test_format_event_line_uses_sorted_compact_json(self):
+        env = make_envelope(DownloadEventType.CAPABILITY,
+                            session_id="s1", timestamp="2026-05-17T10:00:00Z")
+        env["b"] = 1
+        env["a"] = 2
+        line = format_event_line(env)
+        prefix, payload = line.split(" ", 1)
+        self.assertEqual(prefix, DOWNLOAD_EVENT_LOG_PREFIX)
+        # sorted keys -> "a" comes before "b" in the serialization
+        self.assertLess(payload.index('"a"'), payload.index('"b"'))
+
+
+class TestRedaction(unittest.TestCase):
+    def test_denylisted_keys_are_dropped_from_envelope(self):
+        env = make_envelope(DownloadEventType.SESSION_STATE,
+                            session_id="s1", timestamp="2026-05-17T10:00:00Z")
+        env["url"] = "https://example.com/secret"
+        env["cookies"] = "CloudFront-Policy=abc"
+        env["finalPath"] = "/Users/foo/bar"
+        env["tempPath"] = "/Users/foo/bar.part"
+        env["state"] = "downloading"
+        line = format_event_line(env)
+        payload = _parse_line(line)
+        self.assertNotIn("url", payload)
+        self.assertNotIn("cookies", payload)
+        self.assertNotIn("finalPath", payload)
+        self.assertNotIn("tempPath", payload)
+        self.assertEqual(payload["state"], "downloading")
+
+    def test_capability_event_rejects_non_host_strings(self):
+        event = make_capability_event(
+            session_id="s1",
+            resume_enabled=True,
+            validated_hosts=[
+                "cdn.example.com",
+                "evil.example.com/path",   # rejected: path
+                "?query=bad",              # rejected: query
+                "http://withscheme.com",   # rejected: contains "/"
+                " ",                       # rejected: blank
+                "CDN.Example.Com",         # normalized to lowercase, dedup'd
+            ],
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertEqual(event["validatedHosts"], ["cdn.example.com"])
+
+    def test_session_summary_redacts_disallowed_keys(self):
+        bad_summary = {
+            "sessionId": "s1",
+            "url": "https://cdn.example.com/V16/secret",
+            "finalPath": "/Users/foo/bar",
+            "totals": {"attempts": 3, "successes": 2},
+        }
+        event = make_session_summary_event(
+            session_id="s1",
+            summary=bad_summary,
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        line = format_event_line(event)
+        payload = _parse_line(line)
+        # Top-level summary still includes legit fields but not the
+        # denylisted ones (note: nested denial is the caller's
+        # responsibility; downloadObservability never produces them).
+        self.assertNotIn("url", payload["summary"])
+        self.assertNotIn("finalPath", payload["summary"])
+        self.assertIn("totals", payload["summary"])
+
+
+class TestSessionStateEvent(unittest.TestCase):
+    def test_full_payload(self):
+        event = make_session_state_event(
+            session_id="s1",
+            state="downloading",
+            previous_state="preparing",
+            files_planned=10,
+            bytes_planned=5000,
+            concurrency_planned=8,
+            action_id="install",
+            repository_major_version=16,
+            repository_revision=123456,
+            reason="curl_started",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        line = format_event_line(event)
+        payload = _parse_line(line)
+        self.assertEqual(payload["event"], "download.session_state")
+        self.assertEqual(payload["state"], "downloading")
+        self.assertEqual(payload["previousState"], "preparing")
+        self.assertEqual(payload["filesPlanned"], 10)
+        self.assertEqual(payload["bytesPlanned"], 5000)
+        self.assertEqual(payload["concurrencyPlanned"], 8)
+        self.assertEqual(payload["actionId"], "install")
+        self.assertEqual(payload["repositoryMajorVersion"], 16)
+        self.assertEqual(payload["repositoryRevision"], 123456)
+        self.assertEqual(payload["reason"], "curl_started")
+
+    def test_live_progress_fields_present_when_supplied(self):
+        # In-flight download ticks carry cumulative bytes/files
+        # and a smoothed throughput so Central can compute a live ETA.
+        event = make_session_state_event(
+            session_id="s1",
+            state="downloading",
+            bytes_planned=5000,
+            bytes_received=1234,
+            files_completed=3,
+            observed_throughput_bytes_per_second=456,
+            reason="download_progress",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertEqual(event["bytesReceived"], 1234)
+        self.assertEqual(event["filesCompleted"], 3)
+        self.assertEqual(event["observedThroughputBytesPerSecond"], 456)
+
+    def test_phase_progress_fields_present_when_supplied(self):
+        # Post-download phases (e.g. verify) carry
+        # per-phase byte progress so Central can drive a determinate install bar.
+        event = make_session_state_event(
+            session_id="s1",
+            state="verifying_downloads",
+            phase_bytes_done=4096,
+            phase_bytes_planned=8192,
+            reason="verify_progress",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertEqual(event["phaseBytesDone"], 4096)
+        self.assertEqual(event["phaseBytesPlanned"], 8192)
+
+    def test_live_progress_fields_absent_on_lifecycle_transitions(self):
+        # Lifecycle-transition events (no live fields supplied) must keep their
+        # original shape so existing consumers/fixtures are unaffected.
+        event = make_session_state_event(
+            session_id="s1",
+            state="downloading",
+            files_planned=10,
+            bytes_planned=5000,
+            reason="download_started",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertNotIn("bytesReceived", event)
+        self.assertNotIn("filesCompleted", event)
+        self.assertNotIn("observedThroughputBytesPerSecond", event)
+
+
+class TestFileStateEvent(unittest.TestCase):
+    def test_file_state_event_shape(self):
+        event = make_file_state_event(
+            session_id="s1",
+            file_id="deadbeef",
+            repo_path="foo/bar.bundle",
+            state="failed_retryable",
+            previous_state="downloading",
+            expected_size=12345,
+            received_bytes=678,
+            retry_count=2,
+            last_failure_class=DownloadFailureClass.TIMEOUT_DURING_TRANSFER,
+            resumed=False,
+            host="cdn.example.com",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        line = format_event_line(event)
+        payload = _parse_line(line)
+        self.assertEqual(payload["event"], "download.file_state")
+        self.assertEqual(payload["fileId"], "deadbeef")
+        self.assertEqual(payload["repoPath"], "foo/bar.bundle")
+        self.assertEqual(payload["state"], "failed_retryable")
+        self.assertEqual(payload["previousState"], "downloading")
+        self.assertEqual(payload["expectedSize"], 12345)
+        self.assertEqual(payload["receivedBytes"], 678)
+        self.assertEqual(payload["retryCount"], 2)
+        self.assertEqual(payload["lastFailureClass"], "timeout_during_transfer")
+        self.assertFalse(payload["resumed"])
+        self.assertEqual(payload["host"], "cdn.example.com")
+
+
+class TestCapabilityEvent(unittest.TestCase):
+    def test_capability_event_includes_versions(self):
+        event = make_capability_event(
+            session_id="s1",
+            resume_enabled=True,
+            validated_hosts=["cdn.example.com"],
+            retry_matrix_version=1,
+            state_schema_version=1,
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertTrue(event["resumeEnabled"])
+        self.assertEqual(event["validatedHosts"], ["cdn.example.com"])
+        self.assertEqual(event["retryMatrixVersion"], 1)
+        self.assertEqual(event["stateSchemaVersion"], 1)
+        self.assertEqual(event["eventSchemaVersion"], DOWNLOAD_EVENT_SCHEMA_VERSION)
+
+    def test_capability_event_optional_fields_default_when_omitted(self):
+        # when the caller omits the optional fields the builder still emits
+        # sensible defaults so Central always sees a complete envelope
+        event = make_capability_event(
+            session_id="s1",
+            resume_enabled=False,
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertEqual(event["featureFlags"], {})
+        self.assertFalse(event["centralUxEnabled"])
+        self.assertTrue(event["telemetryEnabled"])
+        self.assertTrue(event["retryPolicyEnabled"])
+
+    def test_capability_event_redacts_feature_flag_keys(self):
+        event = make_capability_event(
+            session_id="s1",
+            resume_enabled=True,
+            feature_flags={
+                "DOWNLOAD_RESUME_ENABLED": True,
+                "DOWNLOAD_TELEMETRY_ENABLED": "yes",  # coerced bool
+                "": True,  # empty key dropped
+            },
+            central_ux_enabled=True,
+            telemetry_enabled=False,
+            retry_policy_enabled=False,
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertEqual(event["featureFlags"], {
+            "DOWNLOAD_RESUME_ENABLED": True,
+            "DOWNLOAD_TELEMETRY_ENABLED": True,
+        })
+        self.assertTrue(event["centralUxEnabled"])
+        self.assertFalse(event["telemetryEnabled"])
+        self.assertFalse(event["retryPolicyEnabled"])
+
+
+class _FakeVar:
+    def __init__(self, value):
+        self._value = value
+
+    def bool(self):
+        if isinstance(self._value, bool):
+            return self._value
+        return str(self._value).strip().lower() in ("yes", "true", "1", "on")
+
+
+class _FakeConfig:
+    """Stands in for the instl ConfigVarStack: __getitem__ yields a var with .bool()."""
+
+    def __init__(self, values=None):
+        self._values = dict(values or {})
+
+    def __contains__(self, name):
+        return name in self._values
+
+    def __getitem__(self, name):
+        return _FakeVar(self._values[name])
+
+
+class TestActiveFlagsFromConfig(unittest.TestCase):
+    """The featureFlags map reported on the capability event."""
+
+    def test_defaults_match_shipping_yaml_defaults(self):
+        # An undefined key falls back to the declared default, which must agree
+        # with defaults/InstlClient.yaml -- the two used to disagree.
+        flags = active_flags_from_config(_FakeConfig())
+        self.assertEqual(flags, {
+            "DOWNLOAD_TELEMETRY_ENABLED": True,
+            "DOWNLOAD_RESUME_ENABLED": True,
+            "DOWNLOAD_RETRY_POLICY_ENABLED": True,
+            "DOWNLOAD_CENTRAL_UX_ENABLED": True,
+            "DOWNLOAD_RECONCILE_MISSING_OUTPUTS": True,
+            "DOWNLOAD_OFFLINE_HOLD_ENABLED": True,
+            "DOWNLOAD_CURL_STALL_DETECTION": True,
+            "DOWNLOAD_REDOWNLOAD_ALL_BAD_FILES": True,
+            # only a NEW Central that handles backend-hold events without
+            # auto-pausing declares this one
+            "DOWNLOAD_CLIENT_HANDLES_BACKEND_HOLD": False,
+        })
+
+    def test_reads_yes_no_from_config(self):
+        cfg = _FakeConfig({
+            "DOWNLOAD_TELEMETRY_ENABLED": "no",
+            "DOWNLOAD_RETRY_POLICY_ENABLED": "no",
+            "DOWNLOAD_CENTRAL_UX_ENABLED": "yes",
+            "DOWNLOAD_CLIENT_HANDLES_BACKEND_HOLD": "yes",
+        })
+        flags = active_flags_from_config(cfg)
+        self.assertFalse(flags["DOWNLOAD_TELEMETRY_ENABLED"])
+        self.assertFalse(flags["DOWNLOAD_RETRY_POLICY_ENABLED"])
+        self.assertTrue(flags["DOWNLOAD_CENTRAL_UX_ENABLED"])
+        self.assertTrue(flags["DOWNLOAD_CLIENT_HANDLES_BACKEND_HOLD"])
+        # untouched keys still fall back
+        self.assertTrue(flags["DOWNLOAD_OFFLINE_HOLD_ENABLED"])
+
+    def test_unreadable_config_falls_back_to_defaults(self):
+        class Exploding:
+            def __contains__(self, name):
+                raise RuntimeError("config unavailable")
+
+        flags = active_flags_from_config(Exploding())
+        self.assertTrue(flags["DOWNLOAD_TELEMETRY_ENABLED"])
+        self.assertFalse(flags["DOWNLOAD_CLIENT_HANDLES_BACKEND_HOLD"])
+        self.assertIsNone(active_flags_from_config(None).get("missing"))
+
+    def test_flags_flow_onto_the_capability_event(self):
+        flags = active_flags_from_config(_FakeConfig({"DOWNLOAD_TELEMETRY_ENABLED": "no"}))
+        event = make_capability_event(
+            session_id="smoke",
+            resume_enabled=flags["DOWNLOAD_RESUME_ENABLED"],
+            validated_hosts=["cdn.example.com"],
+            feature_flags=flags,
+            central_ux_enabled=flags["DOWNLOAD_CENTRAL_UX_ENABLED"],
+            telemetry_enabled=flags["DOWNLOAD_TELEMETRY_ENABLED"],
+            retry_policy_enabled=flags["DOWNLOAD_RETRY_POLICY_ENABLED"],
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        self.assertFalse(event["featureFlags"]["DOWNLOAD_TELEMETRY_ENABLED"])
+        self.assertFalse(event["telemetryEnabled"])
+        self.assertTrue(event["resumeEnabled"])
+        self.assertEqual(event["validatedHosts"], ["cdn.example.com"])
+        # the line must still serialize after the flag map is attached
+        self.assertIn(DOWNLOAD_EVENT_LOG_PREFIX, format_event_line(event))
+
+
+class TestEmitEvent(unittest.TestCase):
+    def test_emit_event_logs_at_info_with_prefix(self):
+        event = make_session_state_event(
+            session_id="s1",
+            state="preparing",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        with self.assertLogs("downloadEvents", level="INFO") as captured:
+            line = emit_event(event)
+        self.assertIsNotNone(line)
+        self.assertTrue(line.startswith(DOWNLOAD_EVENT_LOG_PREFIX + " "))
+        # The logger should have captured exactly the same line.
+        joined = "\n".join(captured.output)
+        self.assertIn(DOWNLOAD_EVENT_LOG_PREFIX, joined)
+
+
+class TestTelemetryKillSwitch(unittest.TestCase):
+    """Phase 6 P6-002: ``set_telemetry_enabled(False)`` mutes the channel."""
+
+    def tearDown(self):
+        # Restore the default so subsequent tests in the same suite are
+        # not affected by a stuck process-level flag.
+        from downloadEvents import set_telemetry_enabled
+        set_telemetry_enabled(True)
+
+    def test_emit_event_returns_none_when_disabled(self):
+        from downloadEvents import set_telemetry_enabled, is_telemetry_enabled
+        event = make_session_state_event(
+            session_id="s1",
+            state="preparing",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        set_telemetry_enabled(False)
+        self.assertFalse(is_telemetry_enabled())
+        # Assert no INFO line is emitted while the flag is off.
+        logger = logging.getLogger("downloadEvents")
+        records: list = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Handler(level=logging.INFO)
+        logger.addHandler(handler)
+        try:
+            line = emit_event(event)
+        finally:
+            logger.removeHandler(handler)
+        self.assertIsNone(line)
+        self.assertEqual(records, [])
+
+    def test_emit_event_resumes_after_re_enabling(self):
+        from downloadEvents import set_telemetry_enabled
+        set_telemetry_enabled(False)
+        set_telemetry_enabled(True)
+        event = make_session_state_event(
+            session_id="s1",
+            state="preparing",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        with self.assertLogs("downloadEvents", level="INFO") as captured:
+            line = emit_event(event)
+        self.assertIsNotNone(line)
+        self.assertIn(DOWNLOAD_EVENT_LOG_PREFIX, "\n".join(captured.output))
+
+
+class TestPrivacyIntegration(unittest.TestCase):
+    """End-to-end check: a full event line never contains denylisted fields."""
+
+    def test_session_state_line_never_contains_disallowed_keys(self):
+        event = make_session_state_event(
+            session_id="s1",
+            state="downloading",
+            timestamp="2026-05-17T10:00:00Z",
+        )
+        # Attempt to slip secret fields into a mutable copy.
+        event["url"] = "https://cdn.example.com/V16/file?Signature=abc"
+        event["headers"] = "Authorization: Bearer secret"
+        line = format_event_line(event)
+        self.assertNotIn("Signature", line)
+        self.assertNotIn("Bearer", line)
+        self.assertNotIn("Authorization", line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyinstl/test/test_downloadEventsContract.py
+++ b/pyinstl/test/test_downloadEventsContract.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3.12
+
+"""Contract guard for the structured download-event channel.
+
+`test_downloadEvents.py` checks individual builder behavior; this file pins the
+*contract* documented in `docs/download-events.md`: the set of keys each event
+type carries, the schema version, the additive-field invariants, and the privacy
+denylist. The Central consumer (`downloadEventContract.test.tsx`) pins the same
+contract from the other side.
+
+The intent is that any change which would silently break Central — removing or
+renaming a documented field, bumping the schema version, leaking a denylisted key
+— fails here first. Additive fields are explicitly allowed (subset checks, not
+equality), matching the evolution rule in the doc.
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir)))
+
+from downloadEvents import (
+    DOWNLOAD_EVENT_SCHEMA_VERSION,
+    _DISALLOWED_EVENT_FIELDS,
+    format_event_line,
+    make_capability_event,
+    make_file_state_event,
+    make_session_state_event,
+    make_session_summary_event,
+)
+
+# download.retry_decision is covered where its payload type lives, with the retry
+# policy that produces it - nothing here emits one.
+
+# The documented envelope keys (docs/download-events.md §2).
+ENVELOPE_KEYS = {"event", "schemaVersion", "sessionId", "timestamp"}
+
+# Required (always-present) keys per event type (docs §3). Subset checks: adding
+# a NEW optional field is allowed and must not break this; removing/renaming a
+# documented field is a breaking change and must fail here.
+REQUIRED_KEYS = {
+    "download.session_state": ENVELOPE_KEYS | {
+        "state", "previousState", "filesPlanned", "bytesPlanned",
+        "concurrencyPlanned", "actionId", "repositoryMajorVersion",
+        "repositoryRevision", "reason",
+    },
+    "download.file_state": ENVELOPE_KEYS | {
+        "fileId", "repoPath", "state", "previousState", "expectedSize",
+        "receivedBytes", "retryCount", "lastFailureClass", "resumed", "host",
+    },
+    "download.capability": ENVELOPE_KEYS | {
+        "resumeEnabled", "validatedHosts",
+        "retryMatrixVersion", "stateSchemaVersion", "eventSchemaVersion",
+        "featureFlags", "centralUxEnabled", "telemetryEnabled",
+        "retryPolicyEnabled",
+    },
+    "download.session_summary": ENVELOPE_KEYS | {"summary"},
+}
+
+# The live-progress fields are additive and only on in-flight download ticks.
+SESSION_STATE_LIVE_FIELDS = {
+    "bytesReceived", "filesCompleted", "observedThroughputBytesPerSecond",
+}
+
+
+class TestEventContract(unittest.TestCase):
+    def _all_events(self):
+        return {
+            "download.session_state": make_session_state_event(
+                session_id="s1", state="downloading"),
+            "download.file_state": make_file_state_event(
+                session_id="s1", file_id="f1", repo_path="a/b.bundle",
+                state="downloading"),
+            "download.capability": make_capability_event(
+                session_id="s1", resume_enabled=True),
+            "download.session_summary": make_session_summary_event(
+                session_id="s1", summary={"wallMs": 10, "totals": {}}),
+        }
+
+    def test_required_keys_present_for_each_event(self):
+        for event_name, event in self._all_events().items():
+            missing = REQUIRED_KEYS[event_name] - set(event.keys())
+            self.assertEqual(missing, set(),
+                             f"{event_name} dropped documented key(s): {missing}")
+            self.assertEqual(event["event"], event_name)
+
+    def test_schema_version_is_one(self):
+        # Bumping this is a deliberate BREAKING change (renames/removals/retyping).
+        # Additive fields must NOT bump it. See docs/download-events.md §5.
+        self.assertEqual(DOWNLOAD_EVENT_SCHEMA_VERSION, 1)
+        for event in self._all_events().values():
+            self.assertEqual(event["schemaVersion"], 1)
+
+    def test_session_state_live_fields_are_additive(self):
+        # Absent on lifecycle transitions (keeps the base shape stable)...
+        base = make_session_state_event(session_id="s1", state="downloading")
+        self.assertEqual(SESSION_STATE_LIVE_FIELDS & set(base.keys()), set())
+        # ...present on in-flight download ticks, without disturbing required keys.
+        tick = make_session_state_event(
+            session_id="s1", state="downloading",
+            bytes_received=10, files_completed=1,
+            observed_throughput_bytes_per_second=5)
+        self.assertTrue(SESSION_STATE_LIVE_FIELDS <= set(tick.keys()))
+        self.assertTrue(REQUIRED_KEYS["download.session_state"] <= set(tick.keys()))
+
+    def test_denylisted_keys_never_serialized(self):
+        # Even if a caller smuggles a denylisted key in, the formatter drops it.
+        leaky = make_session_state_event(session_id="s1", state="downloading")
+        leaky["url"] = "https://secret/signed?token=abc"
+        leaky["finalPath"] = "/Users/someone/secret"
+        payload = json.loads(format_event_line(leaky).split(" ", 1)[1])
+        for banned in _DISALLOWED_EVENT_FIELDS:
+            self.assertNotIn(banned, payload)
+
+    def test_emitted_line_prefixed_and_sorted(self):
+        line = format_event_line(
+            make_session_state_event(session_id="s1", state="downloading"))
+        prefix, body = line.split(" ", 1)
+        self.assertEqual(prefix, "DOWNLOAD_EVENT")
+        # Keys are emitted sorted so consumers/fixtures are stable.
+        parsed = json.loads(body)
+        self.assertEqual(list(parsed.keys()), sorted(parsed.keys()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyinstl/test/test_downloadFailures.py
+++ b/pyinstl/test/test_downloadFailures.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3.12
+
+import errno
+import os
+import sys
+import urllib.error
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir)))
+
+from downloadFailures import (
+    DownloadFailureClass,
+    classify_curl_exit_code,
+    classify_exception,
+    classify_http_status,
+    curl_error_description,
+    is_retryable_failure_class,
+    retry_after_seconds,
+)
+
+try:
+    import requests
+except Exception:
+    requests = None
+
+
+class TestDownloadFailures(unittest.TestCase):
+    def assert_failure(self, info, failure_class, retryable=None, source=None):
+        self.assertEqual(info.failure_class, failure_class)
+        if retryable is not None:
+            self.assertEqual(info.retryable, retryable)
+        if source is not None:
+            self.assertEqual(info.source, source)
+
+    def test_required_failure_classes_are_defined(self):
+        required_classes = {
+            "dns_resolution",
+            "tcp_connect",
+            "tls",
+            "timeout_before_first_byte",
+            "timeout_during_transfer",
+            "http_429",
+            "http_5xx",
+            "http_auth_policy",
+            "disk_write",
+            "checksum_mismatch",
+            "partial_transfer",
+            "process_terminated",
+            "unknown_download_error",
+        }
+
+        self.assertTrue(required_classes.issubset({failure_class.value for failure_class in DownloadFailureClass}))
+
+    def test_retryability_is_defined_by_failure_class(self):
+        self.assertTrue(is_retryable_failure_class(DownloadFailureClass.HTTP_5XX))
+        self.assertTrue(is_retryable_failure_class("partial_transfer"))
+        self.assertFalse(is_retryable_failure_class(DownloadFailureClass.HTTP_AUTH_POLICY))
+        self.assertFalse(is_retryable_failure_class("unknown_value"))
+
+    def test_curl_exit_codes_map_to_normalized_classes(self):
+        cases = (
+            (3, None, DownloadFailureClass.MALFORMED_URL, False),
+            (5, None, DownloadFailureClass.DNS_RESOLUTION, True),
+            (6, None, DownloadFailureClass.DNS_RESOLUTION, True),
+            (7, None, DownloadFailureClass.TCP_CONNECT, True),
+            (18, None, DownloadFailureClass.PARTIAL_TRANSFER, True),
+            (23, None, DownloadFailureClass.DISK_WRITE, False),
+            (28, 0, DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE, True),
+            (28, 10, DownloadFailureClass.TIMEOUT_DURING_TRANSFER, True),
+            (33, None, DownloadFailureClass.PARTIAL_TRANSFER, True),
+            (35, None, DownloadFailureClass.TLS, False),
+            (52, None, DownloadFailureClass.NETWORK_RECEIVE_ERROR, True),
+            (55, None, DownloadFailureClass.NETWORK_SEND_ERROR, True),
+            (56, None, DownloadFailureClass.NETWORK_RECEIVE_ERROR, True),
+        )
+
+        for exit_code, received_bytes, expected_class, retryable in cases:
+            with self.subTest(exit_code=exit_code, received_bytes=received_bytes):
+                self.assert_failure(
+                    classify_curl_exit_code(exit_code, received_bytes=received_bytes),
+                    expected_class,
+                    retryable,
+                    "curl",
+                )
+
+    def test_curl_http_exit_code_uses_http_status_when_available(self):
+        cases = (
+            (429, DownloadFailureClass.HTTP_429, True),
+            (500, DownloadFailureClass.HTTP_5XX, True),
+            (503, DownloadFailureClass.HTTP_5XX, True),
+            (401, DownloadFailureClass.HTTP_AUTH_POLICY, False),
+            (403, DownloadFailureClass.HTTP_AUTH_POLICY, False),
+            (404, DownloadFailureClass.HTTP_4XX, False),
+        )
+
+        for status_code, expected_class, retryable in cases:
+            with self.subTest(status_code=status_code):
+                info = classify_curl_exit_code(22, http_status=status_code)
+                self.assert_failure(info, expected_class, retryable, "curl")
+                self.assertEqual(info.curl_exit_code, 22)
+                self.assertEqual(info.http_status, status_code)
+
+    def test_http_status_retry_after_is_parsed(self):
+        info = classify_http_status(429, headers={"Retry-After": "17"})
+
+        self.assert_failure(info, DownloadFailureClass.HTTP_429, True, "http_status")
+        self.assertEqual(info.retry_after_seconds, 17)
+        self.assertEqual(retry_after_seconds("not a retry after value"), None)
+
+    def test_curl_error_description_keeps_existing_message_text(self):
+        self.assertEqual(curl_error_description(28), "Operation timeout. The specified time-out period was reached according to the conditions")
+        self.assertEqual(curl_error_description(9999), None)
+
+    @unittest.skipIf(requests is None, "requests unavailable")
+    def test_requests_metadata_exceptions_map_to_taxonomy(self):
+        response = requests.Response()
+        response.status_code = 503
+        response.headers["Retry-After"] = "5"
+
+        cases = (
+            (requests.exceptions.HTTPError("server error", response=response), DownloadFailureClass.HTTP_5XX, True),
+            (requests.exceptions.ConnectTimeout("connect timed out"), DownloadFailureClass.TIMEOUT_BEFORE_FIRST_BYTE, True),
+            (requests.exceptions.ReadTimeout("read timed out"), DownloadFailureClass.TIMEOUT_DURING_TRANSFER, True),
+            (requests.exceptions.SSLError("certificate verify failed"), DownloadFailureClass.TLS, False),
+            (requests.exceptions.ConnectionError("getaddrinfo failed"), DownloadFailureClass.DNS_RESOLUTION, True),
+        )
+
+        for exc, expected_class, retryable in cases:
+            with self.subTest(exc=exc.__class__.__name__):
+                self.assert_failure(classify_exception(exc), expected_class, retryable)
+
+    def test_urllib_metadata_exceptions_map_to_taxonomy(self):
+        http_error = urllib.error.HTTPError(
+            url="https://cdn.example.com/payload",
+            code=403,
+            msg="Forbidden",
+            hdrs={},
+            fp=None,
+        )
+        dns_error = urllib.error.URLError("getaddrinfo failed")
+
+        self.assert_failure(classify_exception(http_error), DownloadFailureClass.HTTP_AUTH_POLICY, False)
+        self.assert_failure(classify_exception(dns_error), DownloadFailureClass.DNS_RESOLUTION, True)
+
+    def test_local_helper_exceptions_map_to_taxonomy(self):
+        cases = (
+            (OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)), DownloadFailureClass.DISK_SPACE, False),
+            (OSError(errno.EACCES, os.strerror(errno.EACCES)), DownloadFailureClass.PERMISSION_DENIED, False),
+            (OSError(errno.EIO, os.strerror(errno.EIO)), DownloadFailureClass.DISK_WRITE, False),
+            (ValueError("bad checksum for temp download"), DownloadFailureClass.CHECKSUM_MISMATCH, True),
+            (RuntimeError("missing temp download '/tmp/file'"), DownloadFailureClass.MISSING_AFTER_TRANSFER, True),
+        )
+
+        for exc, expected_class, retryable in cases:
+            with self.subTest(exc=str(exc)):
+                self.assert_failure(classify_exception(exc), expected_class, retryable)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/pyinstl/test/test_downloadObservability.py
+++ b/pyinstl/test/test_downloadObservability.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3.12
+
+"""Tests for Phase 4 throughput/error sampler (``P4-001``).
+
+These tests run without ``instl`` runtime dependencies. They exercise
+the per-session in-memory aggregator, the privacy rules around URL
+ingestion, the JSON snapshot shape consumed by the controller, and
+atomic summary persistence.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir)))
+
+from downloadFailures import DownloadFailureClass
+from downloadObservability import (
+    DOWNLOAD_OBSERVABILITY_SCHEMA_VERSION,
+    DownloadObservability,
+    DownloadOutcome,
+    end_session,
+    host_from_url,
+    record_outcome,
+    set_plan,
+    start_session,
+)
+
+
+def _read_summary(bookkeeping_dir):
+    """Read back the persisted session-summary.json to assert on its content."""
+    target = Path(bookkeeping_dir).joinpath("download-state", "session-summary.json")
+    with open(target, "r", encoding="utf-8") as rfd:
+        return json.load(rfd)
+
+
+class _FrozenClock:
+    """Monotonic clock that advances only when test code asks it to."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = float(start)
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += float(seconds)
+
+
+class TestHostFromUrl(unittest.TestCase):
+    def test_extracts_host_and_drops_query(self):
+        self.assertEqual(host_from_url("https://cdn.example.com/V16/foo?Signature=abc"), "cdn.example.com")
+
+    def test_normalizes_case(self):
+        self.assertEqual(host_from_url("https://CDN.Example.Com/path"), "cdn.example.com")
+
+    def test_strips_userinfo_and_port(self):
+        self.assertEqual(host_from_url("https://user:pass@cdn.example.com:8443/path"), "cdn.example.com")
+
+    def test_returns_none_for_missing_or_invalid(self):
+        self.assertIsNone(host_from_url(None))
+        self.assertIsNone(host_from_url(""))
+        self.assertIsNone(host_from_url("not-a-url-just-a-string"))
+
+
+class TestObservabilityRecording(unittest.TestCase):
+    def test_record_success_aggregates_per_host_and_totals(self):
+        clock = _FrozenClock()
+        sampler = DownloadObservability(session_id="s1", concurrency_planned=8, wall_clock=clock)
+        sampler.record_outcome(
+            outcome=DownloadOutcome.SUCCESS,
+            url="https://cdn.example.com/V16/a.bundle",
+            bytes_received=1024,
+            transfer_time_seconds=1.0,
+        )
+        sampler.record_outcome(
+            outcome=DownloadOutcome.SUCCESS,
+            host="cdn.example.com",
+            bytes_received=2048,
+            transfer_time_seconds=2.0,
+        )
+        sampler.record_outcome(
+            outcome=DownloadOutcome.FAILED_RETRYABLE,
+            url="https://other.host.example.net/x",
+            failure_class=DownloadFailureClass.HTTP_5XX,
+            bytes_received=0,
+        )
+
+        clock.advance(4.0)
+        sampler.mark_finished()
+        snapshot = sampler.snapshot()
+
+        self.assertEqual(snapshot["schemaVersion"], DOWNLOAD_OBSERVABILITY_SCHEMA_VERSION)
+        self.assertEqual(snapshot["sessionId"], "s1")
+        self.assertEqual(snapshot["concurrencyPlanned"], 8)
+        self.assertEqual(snapshot["totals"]["attempts"], 3)
+        self.assertEqual(snapshot["totals"]["successes"], 2)
+        self.assertEqual(snapshot["totals"]["failuresRetryable"], 1)
+        self.assertEqual(snapshot["totals"]["bytesReceived"], 3072)
+        self.assertEqual(snapshot["totals"]["failureClasses"], {"http_5xx": 1})
+        self.assertEqual(snapshot["errorRate"], 0.3333)
+        self.assertEqual(snapshot["retryableErrorRate"], 0.3333)
+        # wallMs = 4000 -> 3072 B / 4 s = 768 B/s
+        self.assertEqual(snapshot["wallMs"], 4000)
+        self.assertEqual(snapshot["observedThroughputBytesPerSecond"], 768)
+        self.assertIn("cdn.example.com", snapshot["hosts"])
+        self.assertIn("other.host.example.net", snapshot["hosts"])
+        self.assertEqual(snapshot["hosts"]["cdn.example.com"]["attempts"], 2)
+        self.assertEqual(snapshot["hosts"]["cdn.example.com"]["bytesReceived"], 3072)
+        self.assertEqual(snapshot["hosts"]["other.host.example.net"]["failuresRetryable"], 1)
+
+    def test_invalid_outcome_is_dropped(self):
+        sampler = DownloadObservability(wall_clock=_FrozenClock())
+        sampler.record_outcome(outcome="not_a_real_outcome", url="https://cdn.example.com/a")
+        self.assertEqual(sampler.snapshot()["totals"]["attempts"], 0)
+
+    def test_failure_class_string_normalizes_to_enum_value(self):
+        sampler = DownloadObservability(wall_clock=_FrozenClock())
+        sampler.record_outcome(
+            outcome=DownloadOutcome.FAILED_RETRYABLE,
+            url="https://cdn.example.com/a",
+            failure_class="timeout_during_transfer",
+            bytes_received=0,
+        )
+        snapshot = sampler.snapshot()
+        self.assertEqual(snapshot["totals"]["failureClasses"], {"timeout_during_transfer": 1})
+
+    def test_unknown_host_for_missing_url(self):
+        sampler = DownloadObservability(wall_clock=_FrozenClock())
+        sampler.record_outcome(outcome=DownloadOutcome.SUCCESS, bytes_received=10, transfer_time_seconds=0.5)
+        snapshot = sampler.snapshot()
+        self.assertEqual(list(snapshot["hosts"].keys()), ["unknown"])
+
+
+class TestObservabilityPrivacy(unittest.TestCase):
+    def test_snapshot_keys_do_not_leak_query_or_path(self):
+        sampler = DownloadObservability(wall_clock=_FrozenClock())
+        sampler.record_outcome(
+            outcome=DownloadOutcome.SUCCESS,
+            url="https://cdn.example.com/V16/path/to/secret?Signature=PRIVATE&Policy=PRIVATE",
+            bytes_received=10,
+            transfer_time_seconds=0.1,
+        )
+        snapshot = sampler.snapshot()
+        encoded = json.dumps(snapshot)
+        self.assertNotIn("Signature", encoded)
+        self.assertNotIn("Policy", encoded)
+        self.assertNotIn("PRIVATE", encoded)
+        self.assertNotIn("/V16/", encoded)
+        self.assertEqual(list(snapshot["hosts"].keys()), ["cdn.example.com"])
+
+
+class TestObservabilityPersistence(unittest.TestCase):
+    def test_save_and_load_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bookkeeping = Path(tmpdir).joinpath("bookkeeping")
+            sampler = DownloadObservability(session_id="round-trip", wall_clock=_FrozenClock())
+            sampler.set_plan(files_planned=42, bytes_planned=1024 * 1024)
+            sampler.record_outcome(
+                outcome=DownloadOutcome.SUCCESS,
+                url="https://cdn.example.com/V16/a",
+                bytes_received=1024,
+                transfer_time_seconds=0.5,
+            )
+            target = sampler.save(bookkeeping)
+            self.assertIsNotNone(target)
+            self.assertTrue(target.exists())
+            # Snapshot file lives under download-state/session-summary.json
+            expected = bookkeeping.joinpath("download-state", "session-summary.json")
+            self.assertEqual(target, expected)
+
+            loaded = _read_summary(bookkeeping)
+            self.assertEqual(loaded["sessionId"], "round-trip")
+            self.assertEqual(loaded["filesPlanned"], 42)
+            self.assertEqual(loaded["bytesPlanned"], 1024 * 1024)
+            self.assertEqual(loaded["totals"]["successes"], 1)
+            self.assertEqual(loaded["hosts"]["cdn.example.com"]["bytesReceived"], 1024)
+
+
+class TestModuleSingleton(unittest.TestCase):
+    def setUp(self):
+        # Ensure no leftover singleton from a previous test.
+        end_session(None)
+
+    def tearDown(self):
+        end_session(None)
+
+    def test_module_level_record_uses_active_session(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bookkeeping = Path(tmpdir).joinpath("bookkeeping")
+            start_session(session_id="mod", concurrency_planned=4)
+            set_plan(files_planned=2, bytes_planned=200)
+            record_outcome(
+                outcome=DownloadOutcome.SUCCESS,
+                url="https://cdn.example.com/V16/a",
+                bytes_received=100,
+                transfer_time_seconds=0.2,
+            )
+            target = end_session(bookkeeping)
+            self.assertIsNotNone(target)
+            loaded = _read_summary(bookkeeping)
+            self.assertEqual(loaded["sessionId"], "mod")
+            self.assertEqual(loaded["concurrencyPlanned"], 4)
+            self.assertEqual(loaded["totals"]["attempts"], 1)
+            self.assertEqual(loaded["totals"]["successes"], 1)
+
+    def test_record_without_active_session_is_no_op(self):
+        # Should not raise, should not crash.
+        record_outcome(outcome=DownloadOutcome.SUCCESS, url="https://cdn.example.com/a", bytes_received=1)
+        set_plan(1, 1)
+        self.assertIsNone(end_session(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyinstl/test/test_installLifecycle.py
+++ b/pyinstl/test/test_installLifecycle.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3.12
+
+"""Tests for the installation-lifecycle state machine: its missing entry and its
+missing failure exit.
+
+The contract: a run reaches a terminal state whether it succeeds or fails, and no
+state is declared that nothing ever emits. A declared-but-dead member is what made
+the machine impossible to audit.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir)))
+
+try:
+    import pybatch.reportingBatchCommands as rbc
+    FULL_STACK_IMPORT_ERROR = None
+except Exception as ex:  # pragma: no cover - reported as a skip below
+    FULL_STACK_IMPORT_ERROR = ex
+
+
+@unittest.skipIf(FULL_STACK_IMPORT_ERROR is not None,
+                 f"full instl dependencies unavailable: {FULL_STACK_IMPORT_ERROR}")
+class TestStateMachineHasEntryAndExit(unittest.TestCase):
+    def test_failed_is_emitted_for_a_failing_run(self):
+        with mock.patch("pyinstl.downloadEvents.emit_download_state") as emit:
+            rbc.PythonBatchRuntime.emit_failed_session_state(ValueError)
+        emit.assert_called_once_with("failed", reason="ValueError")
+
+    def test_failed_emit_never_breaks_the_error_path(self):
+        with mock.patch("pyinstl.downloadEvents.emit_download_state",
+                        side_effect=RuntimeError("no events")):
+            rbc.PythonBatchRuntime.emit_failed_session_state(ValueError)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/tests/characterization/test_instlclient_copy_golden.py
+++ b/tests/characterization/test_instlclient_copy_golden.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3.12
+
+"""CHARACTERIZATION (golden/snapshot) tests for the ``instl`` CLIENT install path.
+
+These tests LOCK the current observable behavior of ``InstlClient`` /
+``InstlClientCopy`` before the upcoming ``instlClient`` split and the
+``config_vars`` containment work, so those refactors are verifiable:
+
+  * install-item GRAPH RESOLUTION over a synthetic ``!index`` -- inheritance
+    flattening, ``install_sources`` / ``depends`` resolution, and the recursive
+    dependency expansion (``get_recursive_dependencies``) that turns a set of
+    explicitly-requested ("main") iids into the full closure of iids that must
+    be installed;
+  * COPY command generation -- the exact pybatch command (its ``repr``) emitted
+    by ``create_copy_instructions_for_{file,dir,dir_cont,source}`` for ``!file``,
+    ``!dir``, ``!dir_cont`` and wtarred sources, against a synthetic info_map.
+
+Everything here is HERMETIC: no network, no real repo, no svn. The index and the
+info_map are tiny in-memory/synthetic fixtures; the database is ``:memory:``.
+
+Style/fixtures follow the existing characterization goldens
+(``tests/characterization/test_configvar_resolution_golden.py``) and
+``pyinstl/test/test_itemTable.py`` (which builds an ``IndexItemsTable`` on a
+``db_master``): a ``unittest.TestCase`` asserting exact strings / lists, clearing
+shared singleton state in ``setUp``.
+
+WHAT IS PINNED (and WHAT IS NOT) -- see module-level NOTES at the bottom.
+"""
+
+import sys
+import os
+import unittest
+from pathlib import Path
+
+# repo root on path (mirrors the sibling golden + pyinstl/test layout)
+sys.path.append(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir, os.pardir)))
+
+import utils  # noqa: F401  do not remove, prevents cyclic import problems
+from configVar import config_vars
+
+
+REPO_ROOT = Path(os.path.realpath(os.path.join(__file__, os.pardir, os.pardir, os.pardir)))
+DEFAULTS_FOLDER = REPO_ROOT / "defaults"
+
+
+# --------------------------------------------------------------------------
+# A tiny, fully synthetic !index used by the graph-resolution tests.
+#
+#   APP_IID      depends -> LIB_IID ; has a !file + a !dir source
+#   LIB_IID      inherits COMMON_IID ; has a !dir_cont source
+#   COMMON_IID   provides a shared post_copy action (inherited by LIB_IID)
+#   TOUCH_IID    standalone dependency pulled in only via APP_IID->...->depends
+# --------------------------------------------------------------------------
+SYNTHETIC_INDEX = """--- !index
+APP_IID:
+    name: TheApp
+    version: 1.2.3
+    install_sources:
+        - !file src/app.bin
+        - !dir src/AppBundle
+    install_folders:
+        - /opt/dst
+    depends:
+        - LIB_IID
+LIB_IID:
+    name: TheLib
+    install_sources:
+        - !dir_cont src/libdir
+    install_folders:
+        - /opt/dst
+    inherit:
+        - COMMON_IID
+    depends:
+        - TOUCH_IID
+COMMON_IID:
+    name: Common
+    actions:
+        post_copy:
+            - Echo("done common")
+TOUCH_IID:
+    name: Touch
+    install_sources:
+        - !file src/touch.txt
+    install_folders:
+        - /opt/other
+"""
+
+
+class TestInstlClientGraphResolutionGolden(unittest.TestCase):
+    """Pins inheritance flattening, iid->sources mapping and dependency closure
+    for a synthetic index. Pure DB/graph layer -- no filesystem, no info_map.
+
+    Uses IndexYamlReaderBase (the same reader the admin index path uses) over an
+    in-memory DBManager singleton table, clearing it in setUp/tearDown so the two
+    test classes in this module stay isolated and deterministic.
+    """
+
+    def setUp(self):
+        config_vars.clear()
+        config_vars["__INSTL_DEFAULTS_FOLDER__"] = DEFAULTS_FOLDER
+        config_vars["__MAIN_DB_FILE__"] = ":memory:"
+        from pyinstl import IndexYamlReaderBase
+        self.reader = IndexYamlReaderBase(config_vars)
+        self.it = self.reader.items_table
+        self.it.clear_tables()
+        self.it.activate_all_oses()
+        import tempfile
+        tf = tempfile.NamedTemporaryFile(
+            "w", suffix="-index.yaml", delete=False, encoding="utf-8")
+        tf.write(SYNTHETIC_INDEX)
+        tf.close()
+        self._index_path = tf.name
+        self.reader.read_yaml_file(self._index_path)
+        self.it.resolve_inheritance()
+
+    def tearDown(self):
+        try:
+            self.it.clear_tables()
+        except Exception:
+            pass
+        try:
+            os.unlink(self._index_path)
+        except Exception:
+            pass
+        config_vars.clear()
+
+    # ------------------------------------------------------------------
+    def test_all_iids_present(self):
+        self.assertEqual(
+            ["APP_IID", "COMMON_IID", "LIB_IID", "TOUCH_IID"],
+            self.it.get_all_iids())
+
+    def test_sources_for_iid_with_tags(self):
+        # all OSes active -> os-name is prefixed onto each source path.
+        # (this is exactly the (resolved_path, tag) shape that
+        # create_copy_instructions_for_target_folder iterates over.)
+        # get_sources_for_iid only returns sources for iids with a non-zero
+        # install_status (i.e. actually selected for install), so mark it first.
+        self.it.change_status_of_iids(1, ["APP_IID"])  # 1 == "main"
+        app_sources = [tuple(r) for r in self.it.get_sources_for_iid("APP_IID")]
+        self.assertEqual(
+            [('Mac/src/AppBundle', '!dir'),
+             ('Mac/src/app.bin', '!file'),
+             ('Win/src/AppBundle', '!dir'),
+             ('Win/src/app.bin', '!file')],
+            app_sources)
+
+    def test_inherited_action_is_flattened_onto_child(self):
+        # COMMON_IID's post_copy action must be inherited by LIB_IID.
+        lib_post_copy = self.it.get_resolved_details_value_for_iid(
+            "LIB_IID", "post_copy", unique_values=True)
+        self.assertEqual(['Echo("done common")'], lib_post_copy)
+
+    def test_direct_depends_resolution(self):
+        self.assertEqual(
+            ["LIB_IID"],
+            sorted(self.it.get_resolved_details_value_for_iid(
+                "APP_IID", "depends", unique_values=True)))
+        self.assertEqual(
+            ["TOUCH_IID"],
+            sorted(self.it.get_resolved_details_value_for_iid(
+                "LIB_IID", "depends", unique_values=True)))
+
+    def test_recursive_dependency_closure(self):
+        # request only APP_IID as a "main" install; the recursive expansion must
+        # pull in LIB_IID (direct) and TOUCH_IID (transitive via LIB_IID).
+        self.it.change_status_of_iids(1, ["APP_IID"])  # 1 == "main"
+        closure = sorted(self.it.get_recursive_dependencies(look_for_status=1))
+        self.assertEqual(["APP_IID", "LIB_IID", "TOUCH_IID"], closure)
+        # COMMON_IID is an inheritance parent, NOT a dependency: it must NOT be
+        # in the dependency closure.
+        self.assertNotIn("COMMON_IID", closure)
+
+
+# --------------------------------------------------------------------------
+# COPY command generation.
+#
+# InstlClientCopy uses the DBManager singleton tables, so these tests construct
+# a real (offline) client with a minimal set of initial_vars -- the same keys
+# instl_main builds -- targeting Win to keep output deterministic across hosts
+# (Mac targets emit extra chmod/chown commands keyed on uid/gid).
+# --------------------------------------------------------------------------
+SYNTHETIC_INFO_MAP = """\
+src, d, 1
+src/app.bin, f, 1, 1111111111111111111111111111111111111111, 100
+src/AppBundle, d, 1
+src/AppBundle/Contents, f, 1, 2222222222222222222222222222222222222222, 200
+src/libdir, d, 1
+src/libdir/lib.so, f, 1, 3333333333333333333333333333333333333333, 300
+src/big.tar.wtar, f, 1, 4444444444444444444444444444444444444444, 1000
+src/wtardir, d, 1
+src/wtardir/pack.tar.wtar, f, 1, 5555555555555555555555555555555555555555, 700
+"""
+
+
+def _make_copy_client():
+    initial_vars = {
+        "__INSTL_DATA_FOLDER__": REPO_ROOT,
+        "__INSTL_DEFAULTS_FOLDER__": "$(__INSTL_DATA_FOLDER__)/defaults",
+        "__INSTL_EXE_PATH__": REPO_ROOT / "instl",
+        "__ARGV__": [os.fspath(REPO_ROOT / "instl")],
+        "__MAIN_DB_FILE__": ":memory:",
+        # instl_main sets this from sys.frozen during a real boot; this test
+        # constructs the client directly, so it must declare it itself
+        "__INSTL_COMPILED__": "False",
+        "__CURRENT_OS__": "Win",
+        "__CURRENT_OS_SECOND_NAME__": "Win64",
+        "__CURRENT_OS_NAMES__": ["Win", "Win64"],
+        "TARGET_OS": "Win",
+        "COPY_SOURCES_ROOT_DIR": "/sync/root",
+        "__USER_ID__": -1,
+        "__GROUP_ID__": -1,
+        "ACTING_UID": -1,
+        "ACTING_GID": -1,
+        "VENDOR_NAME": "Waves Audio",
+        "APPLICATION_NAME": "Waves Central",
+    }
+    from pyinstl.instlClientCopy import InstlClientCopy
+    client = InstlClientCopy(initial_vars=initial_vars)
+    return client
+
+
+def _child_reprs(accum):
+    """The exact pybatch command sequence an AnonymousAccum would emit."""
+    return [repr(c) for c in accum.child_batch_commands]
+
+
+def native_source(relative_path):
+    """ A copy source under $(COPY_SOURCES_ROOT_DIR) as this platform writes it.
+        The copy commands normalize the joined path when building repr(), so the
+        separators come out native - backslashes on Windows - and a POSIX literal
+        would never match here.
+    """
+    return os.path.normpath(os.path.join("$(COPY_SOURCES_ROOT_DIR)", relative_path))
+
+
+class TestInstlClientCopyGolden(unittest.TestCase):
+    """Pins the pybatch command(s) emitted for each source type against a
+    synthetic info_map. Targets Win so output is host-independent.
+    """
+
+    def setUp(self):
+        config_vars.clear()
+        self.client = _make_copy_client()
+        # clear any rows left by a previous test on the singleton table
+        self.client.info_map_table.clear_all()
+        self.client.info_map_table.files_read_list.clear()
+        import tempfile
+        tf = tempfile.NamedTemporaryFile(
+            "w", suffix="-info_map.txt", delete=False, encoding="utf-8")
+        tf.write(SYNTHETIC_INFO_MAP)
+        tf.close()
+        self._info_map_path = tf.name
+        self.client.info_map_table.read_from_file(
+            self._info_map_path, a_format="text", disable_indexes_during_read=True)
+        self.client.init_copy_vars()
+
+    def tearDown(self):
+        try:
+            self.client.info_map_table.clear_all()
+        except Exception:
+            pass
+        try:
+            os.unlink(self._info_map_path)
+        except Exception:
+            pass
+        config_vars.clear()
+
+    # ------------------------------------------------------------------
+    def test_copy_file_command(self):
+        accum = self.client.create_copy_instructions_for_file("src/app.bin", "TheApp 1.2.3")
+        self.assertEqual(
+            [f'CopyFileToDir(r"{native_source("src/app.bin")}", r".")'],
+            _child_reprs(accum))
+        # plain (non-wtar) file accrues its raw size.
+        self.assertEqual(100, self.client.bytes_to_copy)
+
+    def test_copy_dir_command(self):
+        accum = self.client.create_copy_instructions_for_dir("src/AppBundle", "TheApp 1.2.3")
+        self.assertEqual(
+            [f'CopyDirToDir(r"{native_source("src/AppBundle")}", r".", delete_extraneous_files=True)'],
+            _child_reprs(accum))
+
+    def test_copy_dir_cont_command(self):
+        accum = self.client.create_copy_instructions_for_dir_cont("src/libdir", "TheLib")
+        self.assertEqual(
+            [f'CopyDirContentsToDir(r"{native_source("src/libdir")}", r".")'],
+            _child_reprs(accum))
+
+    def test_copy_wtar_file_emits_unwtar(self):
+        # a wtarred source ("big.tar" stored as "big.tar.wtar") must emit Unwtar,
+        # NOT a plain copy.
+        accum = self.client.create_copy_instructions_for_file("src/big.tar", "Big")
+        self.assertEqual(
+            [f'Unwtar(what_to_unwtar=r"{native_source("src/big.tar.wtar")}", where_to_unwtar=r".")'],
+            _child_reprs(accum))
+
+    def test_wtar_source_plans_the_bytes_its_unwtar_will_report(self):
+        # Unwtar reports the archive's COMPRESSED size, so planning an expanded
+        # estimate left an all-wtar install topping its own bar out below 100%.
+        self.client.create_copy_instructions_for_file("src/big.tar", "Big")
+        self.assertEqual(1000, self.client.bytes_to_copy)
+
+    def test_dir_cont_of_only_wtar_items_plans_its_bytes(self):
+        # this directory emits an Unwtar and nothing else; its bytes used to be
+        # accumulated only when the directory ALSO held non-wtar items
+        accum = self.client.create_copy_instructions_for_dir_cont("src/wtardir", "Packed")
+        self.assertEqual(
+            [f'Unwtar(what_to_unwtar=r"{native_source("src/wtardir")}", where_to_unwtar=r"..")'],
+            _child_reprs(accum))
+        self.assertEqual(700, self.client.bytes_to_copy)
+
+    def test_copy_instructions_for_source_dispatches_on_tag(self):
+        # the (source_path, tag) tuple form used by the per-iid copy loop.
+        for tag, source_path, expected in (
+                ("!file", "src/app.bin",
+                 f'CopyFileToDir(r"{native_source("src/app.bin")}", r".")'),
+                ("!dir", "src/AppBundle",
+                 f'CopyDirToDir(r"{native_source("src/AppBundle")}", r".", delete_extraneous_files=True)'),
+                ("!dir_cont", "src/libdir",
+                 f'CopyDirContentsToDir(r"{native_source("src/libdir")}", r".")'),
+        ):
+            accum = self.client.create_copy_instructions_for_source((source_path, tag), "x")
+            self.assertEqual([expected], _child_reprs(accum), f"tag={tag}")
+
+    def test_unknown_source_tag_raises(self):
+        with self.assertRaises(ValueError):
+            self.client.create_copy_instructions_for_source(("src/app.bin", "!bogus"), "x")
+
+
+# ==========================================================================
+# NOTES -- what these goldens DO and DO NOT pin (read before refactoring):
+#
+# PINNED hermetically:
+#   * inheritance flattening (COMMON_IID action -> LIB_IID),
+#   * iid -> (source_path, tag) mapping incl. os-name prefixing when all oses
+#     are active (get_sources_for_iid),
+#   * direct + recursive dependency expansion (get_recursive_dependencies):
+#     APP_IID -> LIB_IID -> TOUCH_IID, and that inheritance parents are NOT
+#     dependencies,
+#   * the exact pybatch command repr for each source type:
+#       !file       -> CopyFileToDir
+#       !dir        -> CopyDirToDir(..., delete_extraneous_files=True)
+#       !dir_cont   -> CopyDirContentsToDir
+#       wtarred !file -> Unwtar
+#     plus tag dispatch in create_copy_instructions_for_source and the
+#     ValueError on an unknown tag, and bytes_to_copy accrual for a plain file.
+#
+# NOT pinned hermetically (documented gap):
+#   * The full end-to-end create_copy_instructions batch (the whole
+#     batch_accum tree, stages, progress, require-file + have-info-map copies):
+#     it depends on a synced repo layout on disk (HAVE_INFO_MAP_COPY_PATH,
+#     SITE_HAVE_INFO_MAP_PATH), the active-iid status tables populated by the
+#     full command init, and Mac-only chmod/chown/symlink resolution keyed on
+#     real uid/gid -- none of which are stubbable offline without inventing a
+#     fake filesystem. We pin the largest deterministic sub-steps instead: the
+#     per-source command generation (above) and graph resolution.
+#   * Mac-target copy variants (extra ChmodAndChown / Chown / ResolveSymlink
+#     commands) are intentionally NOT pinned: their output embeds host uid/gid
+#     and would be non-deterministic across machines. Win target is used.
+# ==========================================================================
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An install announces almost nothing between "started" and "done". Central drives its progress bar by parsing free text, and whole phases — reading the index, scanning the sync cache, verifying, copying — pass with no signal a UI can act on. A run that fails emits nothing terminal at all, so a broken install and a hung one look identical from outside.

This adds the reporting, and one real speedup on the way past.

**26 files, +3,622 / −66** — of which **+1,925 is production code and +1,697 is tests.**

## The state machine gets an entry and an exit

- **`preparing`** at the top of the client flow for `sync`/`copy`/`synccopy` — covering the yaml and info-map read, item calculation, and the sync-folder scan. That stretch previously reported nothing at all.
- **`failed`** from `PythonBatchRuntime.log_error`, so a failed install is no longer indistinguishable from a hang. This is the one I would most like a second opinion on: it is a new terminal state on the wire.
- **`ready_to_copy`** gives a sync-only run a terminal state. Before, `instl sync` stopped on `verifying_downloads` and never finished.

## The copy phase reports bytes

Planned and done are now the same unit — source bytes. Before, the plan counted wtar items at an expanded estimate while the copy commands reported compressed bytes, so the bar topped out around 77% and then jumped to done. **That leaves `WTAR_RATIO` with no reader, so it goes** — flagging it explicitly since it is a documented config var.

`copying` is announced after folder creation and the pre-copy actions, which contribute no bytes and used to leave the bar at zero.

## Unwtar extracts in parallel

Decompression is CPU-bound and was fully serial. `DOWNLOAD_PARALLEL_UNWTAR` is a kill switch back to the serial path; `DOWNLOAD_PARALLEL_WORKERS: 0` means `os.cpu_count()`.

## The event channel

`downloadEvents` is the structured channel Central reads instead of parsing text. **It does not replace the legacy progress line** — that line must keep being emitted, and does. Redaction is enforced in every helper: hosts may pass, the rest of a URL may not, and local paths are denylisted. `DOWNLOAD_TELEMETRY_ENABLED` turns the whole channel off without touching the text log.

**Scope note:** the channel defines five event types and this emits four. The fifth, `download.retry_decision`, needs the retry policy that produces it, so both it and its tests belong with the download engine rather than here. The docstrings in `downloadEvents` describe the whole contract including that event, so you will see forward references to a `downloadRetry` module that arrives in the next PR.

## Verification

- **78 tests** across the eight modules this adds or touches, all passing — including a `repr`/`eval` round-trip for `ReportDownloadState` under `pybatch/test`, per AGENTS.md §8.
- **Thirteen modules run one per process against `master3`: identical failure sets, zero regressions.**
- `instl doit` against Central's real `Build-index.yaml` from this branch: exit 0, and the emitted script `py_compile`s.
- The same command run against a `master3` worktree produces a **structurally identical** script — 316 lines both, differing only in paths, timestamp and `__INVOCATION_RANDOM_ID__`.
- The two commands this adds to the emitted script were taken from a **real install log** (a two-platform smoke run) and `eval`'d against this branch, then round-tripped through `repr`:

```
ReportDownloadState(r"copying", reason=r"copy_started", phase_bytes_planned=6135563870, prog_num=842)()
ReportDownloadState(r"completed", reason=r"install_complete", prog_num=3195)()
```

Not claimed: a green suite. It is not green here and was not green on `master3`.

## Worth pushing back on

- **`wtarBatchCommands`** is the most intrusive change into existing code here. The parallel path is a module-level picklable function that receives only plain data — no command object, no `config_vars` — and all progress reporting stays on the main process. If you would rather it lived elsewhere, say so.
- **The wire contract is cross-repo.** Central consumes this under `src/services/instl/behaviours/shell/progress/`. `schemaVersion` stays at 1 because every change here is additive.
- **`WTAR_RATIO` removal**, as above.

This is independent of the housekeeping PR — either order works. The download engine itself (transfer, resume, retry policy, verify) follows separately and builds on this.
